### PR TITLE
Add popup:set_position(position, relative)

### DIFF
--- a/lua/nui/popup/border.lua
+++ b/lua/nui/popup/border.lua
@@ -385,6 +385,38 @@ function Border:resize()
   end
 end
 
+function Border:reposition()
+  local props = self.border_props
+
+  if props.type == "complex" then
+    props.position = calculate_position(self)
+  end
+
+  self.win_config.relative = self.popup.win_config.relative
+
+  if self.popup.win_config.bufpos then
+    self.win_config.bufpos = self.popup.win_config.bufpos
+    self.win_config.win = nil
+  end
+  if self.popup.win_config.win then
+    self.win_config.win = self.popup.win_config.win
+    self.win_config.bufpos = nil
+  end
+
+  self.win_config.row = props.position.row
+  self.win_config.col = props.position.col
+
+  if self.winid then
+    vim.api.nvim_win_set_config(
+      self.winid,
+      vim.tbl_extend("force", self.win_config, {
+        row = props.position.row,
+        col = props.position.col,
+      })
+    )
+  end
+end
+
 ---@param edge "'top'" | "'bottom'"
 ---@param text nil | string
 ---@param align nil | "'left'" | "'center'" | "'right'"

--- a/lua/nui/popup/border.lua
+++ b/lua/nui/popup/border.lua
@@ -393,15 +393,8 @@ function Border:reposition()
   end
 
   self.win_config.relative = self.popup.win_config.relative
-
-  if self.popup.win_config.bufpos then
-    self.win_config.bufpos = self.popup.win_config.bufpos
-    self.win_config.win = nil
-  end
-  if self.popup.win_config.win then
-    self.win_config.win = self.popup.win_config.win
-    self.win_config.bufpos = nil
-  end
+  self.win_config.win = self.popup.win_config.win
+  self.win_config.bufpos = self.popup.win_config.bufpos
 
   self.win_config.row = props.position.row
   self.win_config.col = props.position.col


### PR DESCRIPTION
supports popup:set_position(...) when unmounted or mounted

Also supports:
position (required. same as popup_options.position)
relative (optional, same as popup_options.relative, unchanged if not provided)

Let me know what you would change :D

Also, I think `set_size()` popup method needs this change:
```lua
if self.border.win_config then
  self.border:resize()
end
```
Because when using this in config to initialize popup():
```
border = {
style = "none",
}
```
makes `set_size()` error. `attempt to index field 'win_config' (a nil value)`



