### PR TITLE
WIP: Baseline notifications implementation

### DIFF
--- a/lua/nui/notification/controller.lua
+++ b/lua/nui/notification/controller.lua
@@ -1,0 +1,107 @@
+local utils = require("nui.utils")
+
+local notification_ctl = {
+  active_notifications = {
+    topright = {},
+    topleft = {},
+    botright = {},
+    botleft = {},
+  },
+}
+
+local function get_window_height(popup)
+  if popup:has_border() then
+    return popup.border.win_config.height
+  else
+    return popup.win_config.height
+  end
+end
+
+local function is_position_top(position_text)
+  return position_text:sub(1, 3) == "top"
+end
+
+local function get_new_position(position_text, popup, height_diff, demote)
+  local curr = popup.win_config
+  local new_row
+
+  -- FIXME: Why is `popup.height` not already correct when we have a "native" border? 0-indexing?
+  if utils._.is_border_builtin(popup.winid) then
+    height_diff = height_diff + 2
+  end
+
+  -- Move up/down depending if the notification is positioned on top or bottom,
+  -- then in the opposite direction again if demoting
+  if is_position_top(position_text) then
+    new_row = curr.row + (demote and -height_diff or height_diff)
+  else
+    new_row = curr.row + (demote and height_diff or -height_diff)
+  end
+
+  return {
+    col = curr.col,
+    row = new_row,
+    height = curr.height,
+    width = curr.width,
+  }
+end
+
+local function check_moved_window_out_of_bounds(position_text, new_config)
+  -- Check if the edge of the window is beyond the bounds of the editor
+  --
+  -- The "origin" for a window is its top-left corner
+  if is_position_top(position_text) then
+    -- Windows are moved down, 'row' is at the bottom of the window
+    return new_config.row + new_config.height >= utils.get_editor_size().height
+  else
+    -- Windows are moved up
+    return new_config.row <= 1
+  end
+end
+
+notification_ctl.move_notification_windows = function(new_notification)
+  local new_popup = new_notification
+  local last_popup = new_popup
+  local position_text = new_notification.notification_options.position_text
+
+  for _, curr_popup in ipairs(notification_ctl.active_notifications[position_text]) do
+    local new_config = get_new_position(position_text, curr_popup, get_window_height(last_popup))
+
+    if check_moved_window_out_of_bounds(position_text, new_config) then
+      notification_ctl.remove_active_notification(position_text, curr_popup)
+    else
+      new_config.row = new_config.row
+      curr_popup:set_position(new_config)
+    end
+
+    last_popup = curr_popup
+  end
+end
+
+notification_ctl.add_active_notification = function(notification)
+  table.insert(notification_ctl.active_notifications[notification.notification_options.position_text], 1, notification)
+end
+
+-- Don't want to change our list while iterating over it, schedule this to happen
+-- at some point later (order-preserving)
+notification_ctl.remove_active_notification = vim.schedule_wrap(function(position_text, notification)
+  local idx = 0
+  local popup = notification
+
+  if not popup.winid then
+    return
+  end
+
+  for i, p in ipairs(notification_ctl.active_notifications[position_text]) do
+    if p.winid == popup.winid then
+      idx = i
+      break
+    end
+  end
+
+  popup:unmount()
+
+  table.remove(notification_ctl.active_notifications[position_text], idx)
+end)
+
+return notification_ctl

--- a/lua/nui/notification/init.lua
+++ b/lua/nui/notification/init.lua
@@ -1,0 +1,160 @@
+local NotificationCtl = require("nui.notification.controller")
+local Popup = require("nui.popup")
+local defaults = require("nui.utils").defaults
+local is_type = require("nui.utils").is_type
+local utils = require("nui.utils")
+
+-- Emulate a set to denote valid values
+local position_texts = {
+  topleft = true,
+  topright = true,
+  botright = true,
+  botleft = true,
+}
+
+local Notification = setmetatable({
+  name = "Notification",
+  super = Popup,
+}, {
+  __index = Popup.__index,
+})
+
+local function trim_notification_lines(lines)
+  if not is_type("table", lines) then
+    lines = { lines }
+  end
+
+  local editor_cfg = utils.get_editor_size({ height = -4 })
+  local allowed_width = math.floor(editor_cfg.width * 0.3)
+  local allowed_height = math.floor(editor_cfg.height * 0.3)
+  local max_width, filtered = 1, {}
+  local modified
+
+  for i, line in ipairs(lines) do
+    if i >= allowed_height then
+      table.insert(filtered, "…")
+      break
+    end
+
+    if #line >= allowed_width then
+      modified = utils._.truncate_text(line, allowed_width - 3)
+    else
+      modified = line
+    end
+
+    if #modified > max_width then
+      max_width = #modified
+    end
+
+    table.insert(filtered, modified)
+  end
+
+  return {
+    text = filtered,
+    width = max_width,
+    height = #filtered,
+  }
+end
+
+local function calculate_window_position_from_text(text, width, height, is_complex)
+  assert(position_texts[text], "invalid notification position: " .. text)
+
+  local wincfg = {
+    width = math.max(width, 1),
+    height = math.max(height, 1),
+    row = nil,
+    col = nil,
+  }
+
+  -- TODO: Smarter about signcolumn, tabline, statusline, cmdheight, etc.
+  local editor_cfg = utils.get_editor_size({ height = -4 })
+
+  -- Top-left of the editor is (0, 0)
+  if text == "topleft" then
+    wincfg.row = 1
+    wincfg.col = 1
+  elseif text == "topright" then
+    wincfg.row = 1
+    wincfg.col = editor_cfg.width - wincfg.width - 1
+  elseif text == "botleft" then
+    -- FIXME: The `+2` "assumes" a complex border, shouldn't be needed in an ideal case
+    wincfg.row = editor_cfg.height - wincfg.height + (is_complex and 1 or 0)
+    wincfg.col = 1
+  else
+    -- FIXME: The `+2` "assumes" a complex border, shouldn't be needed in an ideal case
+    wincfg.row = editor_cfg.height - wincfg.height + (is_complex and 1 or 0)
+    wincfg.col = editor_cfg.width - wincfg.width - 1
+  end
+
+  return wincfg
+end
+
+local function init(class, popup_options, options)
+  popup_options.enter = false
+  popup_options.focusable = false
+  popup_options.buf_options = defaults(popup_options.buf_options, {})
+  popup_options.buf_options.buftype = "nofile"
+
+  -- TODO: Support window-relative positioning by updating below function call
+  popup_options.relative = "editor"
+
+  local _border = popup_options.border
+  local is_complex = _border.text or _border.padding
+
+  local trimmed = trim_notification_lines(options.text)
+  local position = calculate_window_position_from_text(options.position, trimmed.width, trimmed.height, is_complex)
+
+  popup_options.position = {}
+  popup_options.position.row = position.row
+  popup_options.position.col = position.col
+
+  popup_options.size = {}
+  popup_options.size.height = position.height
+  popup_options.size.width = position.width
+
+  local self = class.super.init(class, popup_options)
+
+  self.notification_options = {
+    timeout = (math.floor(options.timeout) or 3) * 1000,
+    text = trimmed.text,
+    showmess = options.showmess,
+    position_text = options.position,
+  }
+
+  return self
+end
+
+function Notification:init(popup_options, options)
+  return init(self, popup_options, options)
+end
+
+function Notification:mount()
+  self.super.mount(self)
+
+  NotificationCtl.move_notification_windows(self)
+  NotificationCtl.add_active_notification(self)
+
+  vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, self.notification_options.text)
+
+  vim.fn.timer_start(self.notification_options.timeout, function()
+    NotificationCtl.remove_active_notification(self.notification_options.position_text, self)
+  end)
+
+  if self.notification_options.showmess then
+    vim.schedule(function()
+      -- Echo individually to (hopefully) avoid "Press Enter to continue" prompts
+      for _, line in ipairs(self.notification_options.text) do
+        vim.api.nvim_echo({ { line } }, true, {})
+      end
+    end)
+  end
+end
+
+local NotificationClass = setmetatable({
+  __index = Notification,
+}, {
+  __call = init,
+  __index = Notification,
+})
+
+return NotificationClass

--- a/lua/nui/popup/border.lua
+++ b/lua/nui/popup/border.lua
@@ -189,30 +189,29 @@ end
 
 local function calculate_position(border)
   local popup = border.popup
-
   local position = vim.deepcopy(popup.popup_props.position)
-
   local char = border.border_props.char
 
   if is_type("map", char) then
     if char.top ~= "" then
-      popup.popup_props.position.row = popup.popup_props.position.row + 1
+      position.row = popup.popup_props.position.row - 1
     end
 
     if char.left ~= "" then
-      popup.popup_props.position.col = popup.popup_props.position.col + 1
+      position.col = popup.popup_props.position.col - 1
     end
   end
 
   local padding = border.border_props.padding
 
+  -- TODO: Test that this actually works
   if padding then
     if padding.top then
-      popup.popup_props.position.row = popup.popup_props.position.row + padding.top
+      position.row = popup.popup_props.position.row + padding.top
     end
 
     if padding.left then
-      popup.popup_props.position.col = popup.popup_props.position.col + padding.left
+      position.col = popup.popup_props.position.col + padding.left
     end
   end
 

--- a/lua/nui/popup/init.lua
+++ b/lua/nui/popup/init.lua
@@ -291,7 +291,7 @@ function Popup:set_size(size)
   local container_info = get_container_info(self)
   props.size = calculate_window_size(size, container_info)
 
-  if self.border.win_config then
+  if self:has_border() then
     self.border:resize()
   end
 
@@ -326,7 +326,7 @@ function Popup:set_position(position, relative)
   local container_info = get_container_info(self)
   props.position = calculate_window_position(position, props.size, container_info)
 
-  if self.border.win_config then
+  if self:has_border() then
     self.border:reposition()
   end
 
@@ -339,6 +339,10 @@ function Popup:set_position(position, relative)
     vim.api.nvim_win_set_config(self.winid, self.win_config)
     self.win_config._enter = enter
   end
+end
+
+function Popup:has_border()
+  return self.border.win_config ~= nil
 end
 
 local PopupClass = setmetatable({

--- a/lua/nui/utils/init.lua
+++ b/lua/nui/utils/init.lua
@@ -3,10 +3,12 @@ local utils = {
   _ = {},
 }
 
-function utils.get_editor_size()
+function utils.get_editor_size(offsets)
+  offsets = offsets or {}
+
   return {
-    width = vim.o.columns,
-    height = vim.o.lines,
+    width = vim.o.columns + (offsets.width or 0),
+    height = vim.o.lines + (offsets.height or 0),
   }
 end
 
@@ -50,6 +52,13 @@ function utils.parse_number_input(v)
   end
 
   return parsed
+end
+
+---@private
+---@param winid number
+---@return boolean
+function utils._.is_border_builtin(winid)
+  return vim.api.nvim_win_get_config(winid).border ~= nil
 end
 
 ---@private


### PR DESCRIPTION
Ref. #3

Super baseline implementation with a handful of things that still need work to have something that is merge-able. Clearly still a work-in-progress, but let me know if you have any initial ideas, etc. @MunifTanjim.

- [ ] Implement demotion for a particular (such that notifications also "fall down" when newer notifications close just as older notifications move when newer ones come in, etc.)
- [ ] Figure out `Popup:set_position` bug (realistically a problem with `Border:reposition` as far as I can tell) where the offset of `+1` gets applied, resulting in a "stair stepping" effect with the `botleft` pre-defined position
- [ ] Allow user to set an arbitrary position, or choose from the pre-defined set (right now only supports one from the pre-defined set)
    - Can provide keys for groups and hooks for users to move their own windows if need be
- [ ] Less random `+/-` to get things to line up (largely solved by a solid bounds checking function as without this, things tend to easily get misaligned)
- [ ] Window-relative option?