### PR TITLE
feature: add hide and show methods

### DIFF
--- a/lua/nui/popup/init.lua
+++ b/lua/nui/popup/init.lua
@@ -284,11 +284,11 @@ function Popup:show()
   end
 
   self.popup_state.loading = true
-  self.popup_state.mounted = true
 
   self:_open_window()
 
   self.popup_state.loading = false
+  self.popup_state.mounted = true
 end
 
 function Popup:unmount()

--- a/lua/nui/popup/init.lua
+++ b/lua/nui/popup/init.lua
@@ -149,7 +149,7 @@ local function init(class, options)
   self.popup_state = {
     loading = false,
     mounted = false,
-    close = true,
+    hidden = true,
   }
 
   self.popup_props = {
@@ -235,11 +235,11 @@ function Popup:mount()
 
   self.popup_state.loading = false
   self.popup_state.mounted = true
-  self.popup_state.closed = false
+  self.popup_state.hidden = false
 end
 
-function Popup:close()
-  if self.popup_state.loading or self.popup_state.closed or not self.popup_state.mounted then
+function Popup:hide()
+  if self.popup_state.loading or self.popup_state.hidden or not self.popup_state.mounted then
     return
   end
 
@@ -256,9 +256,29 @@ function Popup:close()
 
   self.popup_state.loading = false
   self.popup_state.mounted = false
-  self.popup_state.closed = true
+  self.popup_state.hidden = true
 end
 
+function Popup:show()
+  if self.popup_state.loading or not self.popup_state.hidden or self.popup_state.mounted then
+    return
+  end
+
+  self.popup_state.loading = true
+
+  self.border:mount()
+
+  self.winid = vim.api.nvim_open_win(self.bufnr, self.popup_props.win_enter, self.win_config)
+  assert(self.winid, "failed to create popup window")
+
+  for name, value in pairs(self.win_options) do
+    vim.api.nvim_win_set_option(self.winid, name, value)
+  end
+
+  self.popup_state.loading = false
+  self.popup_state.mounted = true
+  self.popup_state.hidden = false
+end
 
 function Popup:unmount()
   if self.popup_state.loading or not self.popup_state.mounted then
@@ -287,7 +307,7 @@ function Popup:unmount()
 
   self.popup_state.loading = false
   self.popup_state.mounted = false
-  self.popup_state.closed = true
+  self.popup_state.hidden = true
 end
 
 -- set keymap for this popup window. if keymap was already set and

--- a/lua/nui/popup/init.lua
+++ b/lua/nui/popup/init.lua
@@ -279,7 +279,7 @@ function Popup:hide()
 end
 
 function Popup:show()
-  if self.popup_state.loading or not self.popup_state.mounted then
+  if self.popup_state.loading or self.popup_state.mounted then
     return
   end
 

--- a/lua/nui/popup/init.lua
+++ b/lua/nui/popup/init.lua
@@ -284,11 +284,11 @@ function Popup:show()
   end
 
   self.popup_state.loading = true
+  self.popup_state.mounted = true
 
   self:_open_window()
 
   self.popup_state.loading = false
-  self.popup_state.mounted = true
 end
 
 function Popup:unmount()

--- a/lua/nui/popup/init.lua
+++ b/lua/nui/popup/init.lua
@@ -275,6 +275,7 @@ function Popup:hide()
   self:_close_window()
 
   self.popup_state.loading = false
+  self.popup_state.mounted = false
 end
 
 function Popup:show()
@@ -287,6 +288,7 @@ function Popup:show()
   self:_open_window()
 
   self.popup_state.loading = false
+  self.popup_state.mounted = true
 end
 
 function Popup:unmount()

--- a/lua/nui/popup/init.lua
+++ b/lua/nui/popup/init.lua
@@ -277,7 +277,7 @@ function Popup:hide()
 end
 
 function Popup:show()
-  if self.popup_state.loading or self.popup_state.mounted then
+  if self.popup_state.loading or not self.popup_state.mounted then
     return
   end
 

--- a/lua/nui/popup/init.lua
+++ b/lua/nui/popup/init.lua
@@ -229,8 +229,9 @@ function Popup:_close_window()
     return
   end
 
+  self.border:unmount()
+
   if vim.api.nvim_win_is_valid(self.winid) then
-    self.border:unmount()
     vim.api.nvim_win_close(self.winid, true)
   end
 

--- a/lua/nui/popup/init.lua
+++ b/lua/nui/popup/init.lua
@@ -209,7 +209,7 @@ function Popup:init(options)
   return init(self, options)
 end
 
-function Popup:mount()
+function Popup:mount(bufnr)
   if self.popup_state.loading or self.popup_state.mounted then
     return
   end
@@ -218,7 +218,7 @@ function Popup:mount()
 
   self.border:mount()
 
-  self.bufnr = vim.api.nvim_create_buf(false, true)
+  self.bufnr = bufnr or vim.api.nvim_create_buf(false, true)
   assert(self.bufnr, "failed to create buffer")
 
   for name, value in pairs(self.buf_options) do


### PR DESCRIPTION
# Description

This PR adds `hide` and `show` methods to the `Popup` component.

I was embedding Neovim's `terminal` into a Popup and unmounting the component it deletes the `buf` also, which makes it impossible to toggle the popup.