### PR TITLE
Feat make ns id required

### DIFF
--- a/lua/nui/line/README.md
+++ b/lua/nui/line/README.md
@@ -60,27 +60,27 @@ It `text` is already a `NuiText` object, it is returned unchanged.
 
 Returns the line content.
 
-### `line:highlight(bufnr, linenr, ns_id?)`
+### `line:highlight(bufnr, ns_id, linenr)`
 
 Applies highlight for the line.
 
 **Parameters**
 
-| Name     | Type     | Description             |
-| -------- | -------- | ----------------------- |
-| `bufnr`  | `number` | buffer number           |
-| `linenr` | `number` | line number (1-indexed) |
-| `ns_id`  | `number` | namespace id            |
+| Name     | Type     | Description                                    |
+| -------- | -------- | ---------------------------------------------- |
+| `bufnr`  | `number` | buffer number                                  |
+| `ns_id`  | `number` | namespace id (use `-1` for fallback namespace) |
+| `linenr` | `number` | line number (1-indexed)                        |
 
-### `line:render(bufnr, linenr_start, linenr_end?, ns_id?)`
+### `line:render(bufnr, ns_id, linenr_start, linenr_end?)`
 
 Sets the line on buffer and applies highlight.
 
 **Parameters**
 
-| Name           | Type     | Description                   |
-| -------------- | -------- | ----------------------------- |
-| `bufnr`        | `number` | buffer number                 |
-| `linenr_start` | `number` | start line number (1-indexed) |
-| `linenr_end`   | `number` | end line number (1-indexed)   |
-| `ns_id`        | `number` | namespace id                  |
+| Name           | Type     | Description                                    |
+| -------------- | -------- | ---------------------------------------------- |
+| `bufnr`        | `number` | buffer number                                  |
+| `ns_id`        | `number` | namespace id (use `-1` for fallback namespace) |
+| `linenr_start` | `number` | start line number (1-indexed)                  |
+| `linenr_end`   | `number` | end line number (1-indexed)                    |

--- a/lua/nui/line/init.lua
+++ b/lua/nui/line/init.lua
@@ -33,28 +33,28 @@ function Line:content()
 end
 
 ---@param bufnr number buffer number
+---@param ns_id number namespace id
 ---@param linenr number line number (1-indexed)
----@param ns_id? number namespace id
 ---@return nil
-function Line:highlight(bufnr, linenr, ns_id)
+function Line:highlight(bufnr, ns_id, linenr)
   local current_byte_start = 0
   for _, text in ipairs(self._texts) do
-    text:highlight(bufnr, linenr, current_byte_start, ns_id)
+    text:highlight(bufnr, ns_id, linenr, current_byte_start)
     current_byte_start = current_byte_start + text:length()
   end
 end
 
 ---@param bufnr number buffer number
+---@param ns_id number namespace id
 ---@param linenr_start number start line number (1-indexed)
 ---@param linenr_end? number end line number (1-indexed)
----@param ns_id? number namespace id
 ---@return nil
-function Line:render(bufnr, linenr_start, linenr_end, ns_id)
+function Line:render(bufnr, ns_id, linenr_start, linenr_end)
   local row_start = linenr_start - 1
   local row_end = linenr_end and linenr_end - 1 or row_start + 1
   local content = self:content()
   vim.api.nvim_buf_set_lines(bufnr, row_start, row_end, false, { content })
-  self:highlight(bufnr, linenr_start, ns_id)
+  self:highlight(bufnr, ns_id, linenr_start)
 end
 
 local LineClass = setmetatable({

--- a/lua/nui/text/README.md
+++ b/lua/nui/text/README.md
@@ -73,7 +73,7 @@ Returns the byte length of the text.
 
 Returns the character length of the text.
 
-### `text:highlight(bufnr, linenr, byte_start, ns_id?)`
+### `text:highlight(bufnr, ns_id, linenr, byte_start)`
 
 Applies highlight for the text.
 
@@ -82,11 +82,11 @@ Applies highlight for the text.
 | Name         | Type     | Description                                        |
 | ------------ | -------- | -------------------------------------------------- |
 | `bufnr`      | `number` | buffer number                                      |
+| `ns_id`      | `number` | namespace id (use `-1` for fallback namespace)     |
 | `linenr`     | `number` | line number (1-indexed)                            |
 | `byte_start` | `number` | start position of the text on the line (0-indexed) |
-| `ns_id`      | `number` | namespace id                                       |
 
-### `text:render(bufnr, linenr_start, byte_start, linenr_end?, byte_end?, ns_id?)`
+### `text:render(bufnr, ns_id, linenr_start, byte_start, linenr_end?, byte_end?)`
 
 Sets the text on buffer and applies highlight.
 
@@ -95,13 +95,13 @@ Sets the text on buffer and applies highlight.
 | Name           | Type     | Description                                        |
 | -------------- | -------- | -------------------------------------------------- |
 | `bufnr`        | `number` | buffer number                                      |
+| `ns_id`        | `number` | namespace id (use `-1` for fallback namespace)     |
 | `linenr_start` | `number` | start line number (1-indexed)                      |
 | `byte_start`   | `number` | start position of the text on the line (0-indexed) |
 | `linenr_end`   | `number` | end line number (1-indexed)                        |
 | `byte_end`     | `number` | end position of the text on the line (0-indexed)   |
-| `ns_id`        | `number` | namespace id                                       |
 
-### `text:render_char(bufnr, linenr_start, char_start, linenr_end?, char_end?, ns_id?)`
+### `text:render_char(bufnr, ns_id, linenr_start, char_start, linenr_end?, char_end?)`
 
 Sets the text on buffer and applies highlight.
 
@@ -114,8 +114,8 @@ byte count for you.
 | Name           | Type     | Description                                        |
 | -------------- | -------- | -------------------------------------------------- |
 | `bufnr`        | `number` | buffer number                                      |
+| `ns_id`        | `number` | namespace id (use `-1` for fallback namespace)     |
 | `linenr_start` | `number` | start line number (1-indexed)                      |
 | `char_start`   | `number` | start position of the text on the line (0-indexed) |
 | `linenr_end`   | `number` | end line number (1-indexed)                        |
 | `char_end`     | `number` | end position of the text on the line (0-indexed)   |
-| `ns_id`        | `number` | namespace id                                       |

--- a/lua/nui/text/init.lua
+++ b/lua/nui/text/init.lua
@@ -53,11 +53,11 @@ function Text:width()
 end
 
 ---@param bufnr number buffer number
+---@param ns_id number namespace id
 ---@param linenr number line number (1-indexed)
 ---@param byte_start number start byte position (0-indexed)
----@param ns_id? number namespace id
 ---@return nil
-function Text:highlight(bufnr, linenr, byte_start, ns_id)
+function Text:highlight(bufnr, ns_id, linenr, byte_start)
   if not self.extmark then
     return
   end
@@ -74,13 +74,13 @@ function Text:highlight(bufnr, linenr, byte_start, ns_id)
 end
 
 ---@param bufnr number buffer number
+---@param ns_id number namespace id
 ---@param linenr_start number start line number (1-indexed)
 ---@param byte_start number start byte position (0-indexed)
 ---@param linenr_end? number end line number (1-indexed)
 ---@param byte_end? number end byte position (0-indexed)
----@param ns_id? number namespace id
 ---@return nil
-function Text:render(bufnr, linenr_start, byte_start, linenr_end, byte_end, ns_id)
+function Text:render(bufnr, ns_id, linenr_start, byte_start, linenr_end, byte_end)
   local row_start = linenr_start - 1
   local row_end = linenr_end and linenr_end - 1 or row_start
 
@@ -91,20 +91,20 @@ function Text:render(bufnr, linenr_start, byte_start, linenr_end, byte_end, ns_i
 
   vim.api.nvim_buf_set_text(bufnr, row_start, col_start, row_end, col_end, { content })
 
-  self:highlight(bufnr, linenr_start, byte_start, ns_id)
+  self:highlight(bufnr, ns_id, linenr_start, byte_start)
 end
 
 ---@param bufnr number buffer number
+---@param ns_id number namespace id
 ---@param linenr_start number start line number (1-indexed)
 ---@param char_start number start character position (0-indexed)
 ---@param linenr_end? number end line number (1-indexed)
 ---@param char_end? number end character position (0-indexed)
----@param ns_id? number namespace id
 ---@return nil
-function Text:render_char(bufnr, linenr_start, char_start, linenr_end, char_end, ns_id)
+function Text:render_char(bufnr, ns_id, linenr_start, char_start, linenr_end, char_end)
   char_end = char_end or char_start + self:width()
   local byte_range = _.char_to_byte_range(bufnr, linenr_start, char_start, char_end)
-  self:render(bufnr, linenr_start, byte_range[1], linenr_end, byte_range[2], ns_id)
+  self:render(bufnr, ns_id, linenr_start, byte_range[1], linenr_end, byte_range[2])
 end
 
 local TextClass = setmetatable({

--- a/lua/nui/utils/init.lua
+++ b/lua/nui/utils/init.lua
@@ -68,12 +68,12 @@ function utils._.char_to_byte_range(bufnr, linenr, char_start, char_end)
   return { byte_start, byte_end }
 end
 
-local default_ns_id = vim.api.nvim_create_namespace("nui.nvim")
+local fallback_namespace_id = vim.api.nvim_create_namespace("nui.nvim")
 ---@private
----@param ns_id? number
+---@param ns_id number
 ---@return number
 function utils._.ensure_namespace_id(ns_id)
-  return ns_id or default_ns_id
+  return ns_id == -1 and fallback_namespace_id or ns_id
 end
 
 ---@private

--- a/tests/nui/line/init_spec.lua
+++ b/tests/nui/line/init_spec.lua
@@ -99,7 +99,7 @@ describe("nui.line", function()
       end
 
       it("is applied with :render", function()
-        line:render(bufnr, linenr, nil, ns_id)
+        line:render(bufnr, ns_id, linenr)
 
         assert_highlight()
       end)
@@ -107,7 +107,7 @@ describe("nui.line", function()
       it("can highlight existing buffer line", function()
         vim.api.nvim_buf_set_lines(bufnr, linenr - 1, -1, false, { t1:content() .. t2:content() .. t3:content() })
 
-        line:highlight(bufnr, linenr, ns_id)
+        line:highlight(bufnr, ns_id, linenr)
 
         assert_highlight()
       end)
@@ -120,7 +120,7 @@ describe("nui.line", function()
         local line = Line()
         line:append("4")
         line:append("2")
-        line:render(bufnr, linenr)
+        line:render(bufnr, -1, linenr)
 
         eq(vim.api.nvim_buf_get_lines(bufnr, linenr - 1, linenr, false), {
           "42",

--- a/tests/nui/text/init_spec.lua
+++ b/tests/nui/text/init_spec.lua
@@ -48,12 +48,10 @@ describe("nui.text", function()
 
       text:set("3", {
         hl_group = hl_group,
-        ns_id = 0,
       })
       eq(text:content(), "3")
       eq(text.extmark, {
         hl_group = hl_group,
-        ns_id = 0,
       })
     end)
   end)
@@ -144,7 +142,7 @@ describe("nui.text", function()
         reset_lines()
         linenr, byte_start = 1, 0
         text = Text("a", hl_group)
-        text:render(bufnr, linenr, byte_start, nil, nil, ns_id)
+        text:render(bufnr, ns_id, linenr, byte_start)
         assert_highlight()
       end)
 
@@ -152,7 +150,7 @@ describe("nui.text", function()
         reset_lines()
         linenr, byte_start = 1, 0
         text = Text(multibyte_char, hl_group)
-        text:render_char(bufnr, linenr, byte_start, nil, nil, ns_id)
+        text:render_char(bufnr, ns_id, linenr, byte_start)
         assert_highlight()
       end)
 
@@ -160,7 +158,7 @@ describe("nui.text", function()
         reset_lines()
         linenr, byte_start = 2, 0
         text = Text(initial_lines[linenr], hl_group)
-        text:highlight(bufnr, linenr, byte_start, ns_id)
+        text:highlight(bufnr, ns_id, linenr, byte_start)
         assert_highlight()
       end)
 
@@ -169,11 +167,11 @@ describe("nui.text", function()
         linenr, byte_start = 2, 0
         text = Text(initial_lines[linenr], hl_group)
 
-        text:highlight(bufnr, linenr, byte_start, ns_id)
+        text:highlight(bufnr, ns_id, linenr, byte_start)
         assert_highlight()
-        text:highlight(bufnr, linenr, byte_start, ns_id)
+        text:highlight(bufnr, ns_id, linenr, byte_start)
         assert_highlight()
-        text:highlight(bufnr, linenr, byte_start, ns_id)
+        text:highlight(bufnr, ns_id, linenr, byte_start)
         assert_highlight()
       end)
     end)
@@ -186,10 +184,10 @@ describe("nui.text", function()
 
         spy.on(text, "highlight")
 
-        text:render(bufnr, 1, 1)
+        text:render(bufnr, -1, 1, 1)
 
         assert.spy(text.highlight).was_called(1)
-        assert.spy(text.highlight).was_called_with(text, bufnr, 1, 1, nil)
+        assert.spy(text.highlight).was_called_with(text, bufnr, -1, 1, 1)
 
         eq(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), {
           " a1",
@@ -205,10 +203,10 @@ describe("nui.text", function()
 
         spy.on(text, "highlight")
 
-        text:render(bufnr, 2, vim.fn.strlen(multibyte_char))
+        text:render(bufnr, -1, 2, vim.fn.strlen(multibyte_char))
 
         assert.spy(text.highlight).was_called(1)
-        assert.spy(text.highlight).was_called_with(text, bufnr, 2, vim.fn.strlen(multibyte_char), nil)
+        assert.spy(text.highlight).was_called_with(text, bufnr, -1, 2, vim.fn.strlen(multibyte_char))
 
         eq(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), {
           initial_lines[1],
@@ -226,10 +224,10 @@ describe("nui.text", function()
 
         spy.on(text, "highlight")
 
-        text:render_char(bufnr, 1, 1)
+        text:render_char(bufnr, -1, 1, 1)
 
         assert.spy(text.highlight).was_called(1)
-        assert.spy(text.highlight).was_called_with(text, bufnr, 1, 1, nil)
+        assert.spy(text.highlight).was_called_with(text, bufnr, -1, 1, 1)
 
         eq(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), {
           " a1",
@@ -245,10 +243,10 @@ describe("nui.text", function()
 
         spy.on(text, "highlight")
 
-        text:render_char(bufnr, 2, 1)
+        text:render_char(bufnr, -1, 2, 1)
 
         assert.spy(text.highlight).was_called(1)
-        assert.spy(text.highlight).was_called_with(text, bufnr, 2, vim.fn.strlen(multibyte_char), nil)
+        assert.spy(text.highlight).was_called_with(text, bufnr, -1, 2, vim.fn.strlen(multibyte_char))
 
         eq(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), {
           initial_lines[1],


### PR DESCRIPTION
make ns_id required, update method signature 

makes ns_id required for :highlight, :render, :render_char methods.
if -1 is provided, a fallback ns_id will be used.

BREAKING CHANGE: change parameter order for methods.

---

Better do this now, sooner than later. Explicitly using namespace with extmarks is preferred.