### PR TITLE
feat(menu): pass reference of menu to on_change event

### DIFF
--- a/lua/nui/menu/README.md
+++ b/lua/nui/menu/README.md
@@ -115,7 +115,7 @@ keymap = {
 },
 ```
 
-### `on_change(item)`
+### `on_change(item, menu)`
 
 **Type:** `function`
 

--- a/lua/nui/menu/init.lua
+++ b/lua/nui/menu/init.lua
@@ -91,9 +91,7 @@ local function init(class, popup_options, options)
   local props = vim.tbl_extend("force", {
     separator = defaults(options.separator, {}),
     keymap = parse_keymap(options.keymap),
-  }, prepare_lines(
-    options.lines
-  ))
+  }, prepare_lines(options.lines))
 
   local width = math.max(
     math.min(props._max_line_width, defaults(options.max_width, 999)),

--- a/lua/nui/menu/init.lua
+++ b/lua/nui/menu/init.lua
@@ -83,7 +83,7 @@ local function focus_item(menu, direction, current_id)
 
   if next_id then
     vim.api.nvim_win_set_cursor(menu.winid, { next_id, 0 })
-    menu.menu_props._on_change(next_node)
+    menu.menu_props._on_change(next_node, menu)
   end
 end
 
@@ -91,7 +91,9 @@ local function init(class, popup_options, options)
   local props = vim.tbl_extend("force", {
     separator = defaults(options.separator, {}),
     keymap = parse_keymap(options.keymap),
-  }, prepare_lines(options.lines))
+  }, prepare_lines(
+    options.lines
+  ))
 
   local width = math.max(
     math.min(props._max_line_width, defaults(options.max_width, 999)),
@@ -118,7 +120,7 @@ local function init(class, popup_options, options)
 
   props._on_change = function(node)
     if options.on_change then
-      options.on_change(node)
+      options.on_change(node, self)
     end
   end
 
@@ -251,7 +253,7 @@ function Menu:mount()
     local node = self._tree:get_node(node_id)
     if node.type == "item" then
       vim.api.nvim_win_set_cursor(self.winid, { node_id, 0 })
-      props._on_change(node)
+      props._on_change(node, self)
       break
     end
   end

--- a/tests/nui/menu/init_spec.lua
+++ b/tests/nui/menu/init_spec.lua
@@ -35,19 +35,19 @@ describe("nui.menu", function()
     menu:mount()
 
     -- initial focus
-    assert.spy(on_change).called_with(lines[1])
+    assert.spy(on_change).called_with(lines[1], menu)
     on_change:clear()
 
     feedkeys("j", "x")
-    assert.spy(on_change).called_with(lines[2])
+    assert.spy(on_change).called_with(lines[2], menu)
     on_change:clear()
 
     feedkeys("j", "x")
-    assert.spy(on_change).called_with(lines[1])
+    assert.spy(on_change).called_with(lines[1], menu)
     on_change:clear()
 
     feedkeys("k", "x")
-    assert.spy(on_change).called_with(lines[2])
+    assert.spy(on_change).called_with(lines[2], menu)
     on_change:clear()
   end)
 end)


### PR DESCRIPTION
Use case:

```lua
    on_change = function(item, menu)
      local progress = 0
      local pos = nil
      for i, val in pairs(menu_items) do
        if val == item then
          pos = i
        end
      end

      progress = math.floor((pos / #menu_items) * 100)
      menu.border:set_text('bottom', tostring(progress), 'right')
    end,
```

Not really sure if you would have preferred the reference to menu attached to the node rather than passed as a parameter but I think is pretty nice. Confirmed working as well.

Let me know what you think about this! 😄 