### PR TITLE
feat(text): improve extmark handling

### DIFF
--- a/lua/nui/text/init.lua
+++ b/lua/nui/text/init.lua
@@ -11,7 +11,7 @@ local Text = Object("NuiText")
 function Text:init(content, extmark)
   if is_type("table", content) then
     -- cloning
-    self:set(content._content, content.extmark)
+    self:set(content._content, extmark or content.extmark)
   else
     self:set(content, extmark)
   end

--- a/lua/nui/text/init.lua
+++ b/lua/nui/text/init.lua
@@ -28,8 +28,10 @@ function Text:set(content, extmark)
   end
 
   if extmark then
+    -- preserve self.extmark.id
+    local id = self.extmark and self.extmark.id or nil
     self.extmark = is_type("string", extmark) and { hl_group = extmark } or vim.deepcopy(extmark)
-    self.extmark.id = nil
+    self.extmark.id = id
   end
 
   return self

--- a/tests/nui/text/init_spec.lua
+++ b/tests/nui/text/init_spec.lua
@@ -14,19 +14,35 @@ describe("nui.text", function()
   end)
 
   it("can clone nui.text object", function()
-    local content = "42"
     local hl_group = "NuiTextTest"
 
-    local t1 = Text(content, hl_group)
+    local t1 = Text("42", hl_group)
 
+    t1.extmark.id = 42
     local t2 = Text(t1)
-    eq(t1:content(), t2:content())
-    eq(t1.extmark, t2.extmark)
+    eq(t2:content(), t1:content())
+    eq(t2.extmark, tbl_omit(t1.extmark, { "id" }))
 
     t2.extmark.id = 42
     local t3 = Text(t2)
-    eq(t2:content(), t3:content())
-    eq(tbl_omit(t2.extmark, { "id" }), t3.extmark)
+    eq(t3:content(), t2:content())
+    eq(t3.extmark, tbl_omit(t2.extmark, { "id" }))
+  end)
+
+  it("can clone nui.text object overriding extmark", function()
+    local hl_group = "NuiTextTest"
+    local hl_group_override = "NuiTextTestOverride"
+
+    local t1 = Text("42", hl_group)
+
+    t1.extmark.id = 42
+    local t2 = Text(t1, hl_group_override)
+    eq(t2:content(), t1:content())
+    eq(t2.extmark, { hl_group = hl_group_override })
+
+    local t3 = Text(t2, { id = 42, hl_group = hl_group })
+    eq(t3:content(), t2:content())
+    eq(t3.extmark, { hl_group = hl_group })
   end)
 
   describe("method :set", function()

--- a/tests/nui/text/init_spec.lua
+++ b/tests/nui/text/init_spec.lua
@@ -47,30 +47,46 @@ describe("nui.text", function()
 
   describe("method :set", function()
     it("works", function()
-      local content = "42"
       local hl_group = "NuiTextTest"
-      local text = Text(content, hl_group)
+      local hl_group_override = "NuiTextTestOverride"
 
-      eq(text:content(), content)
+      local text = Text("42", hl_group)
+
+      eq(text:content(), "42")
       eq(text:length(), 2)
       eq(text.extmark, {
         hl_group = hl_group,
       })
+
+      text.extmark.id = 42
 
       text:set("3")
       eq(text:content(), "3")
       eq(text:length(), 1)
       eq(text.extmark, {
         hl_group = hl_group,
+        id = 42,
       })
 
-      text:set("3", {
-        hl_group = hl_group,
+      text:set("9", hl_group_override)
+      eq(text:content(), "9")
+      eq(text.extmark, {
+        hl_group = hl_group_override,
+        id = 42,
       })
-      eq(text:content(), "3")
+
+      text:set("11", { hl_group = hl_group })
+      eq(text:content(), "11")
       eq(text.extmark, {
         hl_group = hl_group,
+        id = 42,
       })
+
+      text.extmark.id = nil
+
+      text:set("42", { id = 42, hl_group = hl_group })
+      eq(text:content(), "42")
+      eq(text.extmark, { hl_group = hl_group })
     end)
   end)
 


### PR DESCRIPTION
For cloning a text with new highlight group:

```lua
local new_text = Text(old_text, new_hl)
```

When `new_text` is rendered, it will create a new extmark.

---

For updating highlight group for existing text:

```lua
text:set(text:content(), new_hl)
```

When `text` is rendered the next time, if it previously had highlight, the same extmark will be updated and used.