### PR TITLE
Fix `invalid buffer id` in Neo-tree test

### DIFF
--- a/lua/nui/popup/init.lua
+++ b/lua/nui/popup/init.lua
@@ -244,10 +244,11 @@ function Popup:_buf_destory()
     return
   end
 
-  u.clear_namespace(self.bufnr, self.ns_id)
-
-  if not self._.unmanaged_bufnr and vim.api.nvim_buf_is_valid(self.bufnr) then
-    vim.api.nvim_buf_delete(self.bufnr, { force = true })
+  if vim.api.nvim_buf_is_valid(self.bufnr) then
+    u.clear_namespace(self.bufnr, self.ns_id)
+    if not self._.unmanaged_bufnr then
+      vim.api.nvim_buf_delete(self.bufnr, { force = true })
+    end
   end
 
   buf_storage.cleanup(self.bufnr)


### PR DESCRIPTION
This fixes a bug discovered in a Neo-tree test: 
```
Fail    ||      Filesystem reveal command should toggle the reveal-state of the floating window
            .../neo-tree/sources/filesystem/filesystem_command_spec.lua:9: Vim(lua):E5108: Error executing lua ...m/site/pack/packer/start/nui.nvim/lua/nui/utils/init.lua:
121: Invalid buffer id: 11
            stack traceback:
                [C]: in function 'nvim_buf_clear_namespace'
                ...m/site/pack/packer/start/nui.nvim/lua/nui/utils/init.lua:121: in function 'clear_namespace'
                ...m/site/pack/packer/start/nui.nvim/lua/nui/popup/init.lua:247: in function '_buf_destory'
                ...m/site/pack/packer/start/nui.nvim/lua/nui/popup/init.lua:272: in function 'unmount'
                ...eickel/repos/neo-tree.nvim//lua/neo-tree/ui/renderer.lua:141: in function 'close_floating_window'
                /home/cseickel/repos/neo-tree.nvim//lua/neo-tree.lua:82: in function 'float'
                [string ":lua"]:1: in main chunk
                [C]: in function 'cmd'
                .../neo-tree/sources/filesystem/filesystem_command_spec.lua:9: in function 'run_focus_command'
                .../neo-tree/sources/filesystem/filesystem_command_spec.lua:122: in function <.../neo-tree/sources/filesystem/filesystem_command_spec.lua:105>
                [C]: in function 'xpcall'
                ...
                ...te/pack/packer/start/plenary.nvim/lua/plenary/busted.lua:132: in function 'describe'
                .../neo-tree/sources/filesystem/filesystem_command_spec.lua:70: in function <.../neo-tree/sources/filesystem/filesystem_command_spec.lua:40>
                [C]: in function 'xpcall'
                ...te/pack/packer/start/plenary.nvim/lua/plenary/busted.lua:74: in function 'call_inner'
                ...te/pack/packer/start/plenary.nvim/lua/plenary/busted.lua:120: in function 'describe'
                .../neo-tree/sources/filesystem/filesystem_command_spec.lua:40: in main chunk
                [builtin#25]: at 0x5a0ceefabb70
                [C]: in function 'pcall'
                ...te/pack/packer/start/plenary.nvim/lua/plenary/busted.lua:221: in function 'run'
                [string ":lua"]:1: in main chunk
            
            stack traceback:
                .../neo-tree/sources/filesystem/filesystem_command_spec.lua:9: in function 'run_focus_command'
                .../neo-tree/sources/filesystem/filesystem_command_spec.lua:122: in function <.../neo-tree/sources/filesystem/filesystem_command_spec.lua:105>
```

I believe the issue is that I am trying to umnount a window that has already been closed. I think such an action should still work and clean up whatever might have been left behind, which this change will facilitate.

This closes https://github.com/nvim-neo-tree/neo-tree.nvim/issues/496

