### PR TITLE
fix: set noautocmd before opening border window

### DIFF
--- a/lua/nui/popup/border.lua
+++ b/lua/nui/popup/border.lua
@@ -436,7 +436,9 @@ function Border:_open_window()
     return
   end
 
+  self.win_config.noautocmd = true
   self.winid = vim.api.nvim_open_win(self.bufnr, false, self.win_config)
+  self.win_config.noautocmd = nil
   assert(self.winid, "failed to create border window")
 
   if self._.winhighlight then


### PR DESCRIPTION
Currently `noautocmd` is not set (like for the popup window) when opening the border.

This leads to issue with other floats like Telescope.

Fixes Noice issue https://github.com/folke/noice.nvim/issues/11