### PR TITLE
feat: added support for `anchor`

### DIFF
--- a/lua/nui/popup/border.lua
+++ b/lua/nui/popup/border.lua
@@ -347,6 +347,8 @@ local function adjust_popup_win_config(border)
   end
 
   popup.win_config.relative = "win"
+  -- anchor to the border window instead
+  popup.win_config.anchor = "NW"
   popup.win_config.win = border.winid
   popup.win_config.bufpos = nil
   popup.win_config.row = popup_position.row
@@ -428,6 +430,7 @@ function Border:init(popup, options)
     border = "none",
     focusable = false,
     zindex = self.popup.win_config.zindex - 1,
+    anchor = self.popup.win_config.anchor,
   }
 end
 

--- a/lua/nui/popup/init.lua
+++ b/lua/nui/popup/init.lua
@@ -59,7 +59,7 @@ end
 
 ---@alias nui_popup_internal_position { relative: "'cursor'"|"'editor'"|"'win'", win: number, bufpos?: number[], row: number, col: number }
 ---@alias nui_popup_internal_size { height: number, width: number }
----@alias nui_popup_win_config { focusable: boolean, style: "'minimal'", zindex: number, relative: "'cursor'"|"'editor'"|"'win'", win?: number, bufpos?: number[], row: number, col: number, width: number, height: number, border?: table }
+---@alias nui_popup_win_config { focusable: boolean, style: "'minimal'", zindex: number, relative: "'cursor'"|"'editor'"|"'win'", win?: number, bufpos?: number[], row: number, col: number, width: number, height: number, border?: table, anchor?: "NW"|"NE"|"SW"|"SE" }
 ---@alias nui_popup_internal { layout: nui_layout_config, layout_ready: boolean, loading: boolean, mounted: boolean, position: nui_popup_internal_position, size: nui_popup_internal_size, win_enter: boolean, unmanaged_bufnr?: boolean, buf_options: table<string,any>, win_options: table<string,any>, win_config: nui_popup_win_config }
 
 --luacheck: pop
@@ -91,6 +91,7 @@ function Popup:init(options)
     win_config = {
       focusable = options.focusable,
       style = "minimal",
+      anchor = options.anchor,
       zindex = options.zindex,
     },
     augroup = {


### PR DESCRIPTION
Hi!

The `anchor` window option did not exist yet, so I added it.

If there's a border, the popup is anchored to the deafult anchor `NW`. And the border is anchored to the popup `anchor`.

If there's no border, the popup window itself sets the `anchor`.

This should cover all cases I think