### PR TITLE
fix(popup): check if border bufr is valid before clearing namespace

### DIFF
--- a/lua/nui/popup/border.lua
+++ b/lua/nui/popup/border.lua
@@ -505,9 +505,8 @@ function Border:unmount()
   end
 
   if self.bufnr then
-    u.clear_namespace(self.bufnr, self.popup.ns_id)
-
     if vim.api.nvim_buf_is_valid(self.bufnr) then
+      u.clear_namespace(self.bufnr, self.popup.ns_id)
       vim.api.nvim_buf_delete(self.bufnr, { force = true })
     end
     self.bufnr = nil


### PR DESCRIPTION
Some Noice users like to do `%bw` to wipe all buffers (which they shouldn't do, but anyway). This leads to issues in Noice, Nui and Notify.

I've just fixed them all in each project.

Fixes:
- [ ] https://github.com/folke/noice.nvim/issues/292
- [ ] https://github.com/folke/noice.nvim/issues/95
- [ ] https://github.com/folke/noice.nvim/issues/244