### PR TITLE
feat(popup): default border.text hl to FloatTitle

### DIFF
--- a/tests/nui/popup/border_spec.lua
+++ b/tests/nui/popup/border_spec.lua
@@ -471,6 +471,7 @@ describe("nui.popup", function()
       h.assert_buf_lines(popup.border.bufnr, {
         "┌─popup──┐",
       }, 1, 1)
+      h.assert_highlight(popup.border.bufnr, popup_options.ns_id, 1, text, "FloatTitle")
     end)
 
     it("supports nui.text", function()
@@ -481,7 +482,8 @@ describe("nui.popup", function()
         border = {
           style = "single",
           text = {
-            top = Text(text, hl_group),
+            top = Text(text),
+            bottom = Text(text, hl_group),
           },
         },
       })
@@ -493,8 +495,12 @@ describe("nui.popup", function()
       h.assert_buf_lines(popup.border.bufnr, {
         "┌─popup──┐",
       }, 1, 1)
+      h.assert_highlight(popup.border.bufnr, popup_options.ns_id, 1, text, "FloatTitle")
 
-      h.assert_highlight(popup.border.bufnr, popup_options.ns_id, 1, text, hl_group)
+      h.assert_buf_lines(popup.border.bufnr, {
+        "└─popup──┘",
+      }, 4, 4)
+      h.assert_highlight(popup.border.bufnr, popup_options.ns_id, 4, text, hl_group)
     end)
   end)
 


### PR DESCRIPTION
Match the default behavior of Neovim.

References:

> https://github.com/neovim/neovim/blob/92005db76039094d4a7180c1398b43c06940a1a1/runtime/doc/api.txt#L457
> - |hl-FloatTitle| for window's title

> https://github.com/neovim/neovim/blob/92005db76039094d4a7180c1398b43c06940a1a1/runtime/doc/api.txt#L3094-L3096
> default highlight group is `FloatTitle`