### PR TITLE
fix(popup): make sure border buf is modifiable

### DIFF
--- a/lua/nui/popup/border.lua
+++ b/lua/nui/popup/border.lua
@@ -527,6 +527,7 @@ end
 function Border:_buf_create()
   if not self.bufnr or not vim.api.nvim_buf_is_valid(self.bufnr) then
     self.bufnr = vim.api.nvim_create_buf(false, true)
+    vim.bo[self.bufnr].modifiable = true
     assert(self.bufnr, "failed to create border buffer")
   end
 end


### PR DESCRIPTION
When creating a popup on a nonmodifiable buffer, creating the border fails, probably becasue it inherits the nonmodifable option.

Fixes https://github.com/folke/noice.nvim/issues/567