### PR TITLE
fix: end_col out of range

### DIFF
--- a/lua/nui/text/init.lua
+++ b/lua/nui/text/init.lua
@@ -67,10 +67,19 @@ function Text:highlight(bufnr, ns_id, linenr, byte_start)
     return
   end
 
-  self.extmark.end_col = byte_start + self:length()
+  local maxcol = vim.v.maxcol
+  local end_col = byte_start + self:length()
+  if end_col >= 0 and maxcol <= end_col then
+    self.extmark.end_col = end_col
+  end
 
-  self.extmark.id =
-    vim.api.nvim_buf_set_extmark(bufnr, _.ensure_namespace_id(ns_id), linenr - 1, byte_start, self.extmark)
+  self.extmark.id = vim.api.nvim_buf_set_extmark(
+    bufnr,
+    _.ensure_namespace_id(ns_id),
+    linenr - 1,
+    byte_start,
+    self.extmark
+  )
 end
 
 ---@param bufnr number buffer number


### PR DESCRIPTION
![end_col-pinia](https://github.com/MunifTanjim/nui.nvim/assets/10345518/726703c9-1c5d-427f-9e1c-bcc8d178dd36)

When using Pinia in the vue3 project, Pinia will throw the following exception when displaying the definition.

![end_col-out-of-range](https://github.com/MunifTanjim/nui.nvim/assets/10345518/193401a9-5021-428e-bc4f-71560de302ee)

Neovim check the range of `end_col`. To avoid exception, verify the range of `end_col` before calling `nvim_buf_set_extmark`.

https://github.com/neovim/neovim/blob/b76cc974b9a5dd206f01872f78e6346e54fb5170/src/nvim/api/extmark.c#L534

![fix-end_col](https://github.com/MunifTanjim/nui.nvim/assets/10345518/576c7601-f4d5-4643-b793-0998011dd914)
