### PR TITLE
Add Missing Internal Fields

### DIFF
--- a/lua/nui/menu/init.lua
+++ b/lua/nui/menu/init.lua
@@ -283,7 +283,7 @@ function Menu:init(popup_options, options)
   self._.sep = options.separator
 
   self._.should_skip_item = defaults(options.should_skip_item, default_should_skip_item)
-  self._.prepare_item = defaults(options.prepare_item, make_default_prepare_node(self))
+  self._.prepare_item = defaults(options.prepare_item, self._.prepare_item)
 
   self.menu_props = {}
 
@@ -314,6 +314,13 @@ function Menu:init(popup_options, options)
   props.on_focus_prev = function()
     focus_item(self, "prev")
   end
+end
+
+---@param config? nui_layout_options
+function Menu:update_layout(config)
+  Menu.super.update_layout(self, config)
+
+  self._.prepare_item = defaults(self._.prepare_item, make_default_prepare_node(self))
 end
 
 function Menu:mount()

--- a/tests/nui/menu/init_spec.lua
+++ b/tests/nui/menu/init_spec.lua
@@ -1,6 +1,7 @@
 pcall(require, "luacov")
 
 local Menu = require("nui.menu")
+local Layout = require("nui.layout")
 local Line = require("nui.line")
 local Text = require("nui.text")
 local h = require("tests.helpers")
@@ -569,6 +570,32 @@ describe("nui.menu", function()
       h.assert_extmark(extmarks[2], linenr, "*", hl_group)
       h.assert_extmark(extmarks[3], linenr, "**", hl_group)
       h.assert_extmark(extmarks[4], linenr, "*", hl_group)
+    end)
+  end)
+
+  describe("w/ Layout", function()
+    it("can be used", function()
+      menu = Menu({}, {
+        lines = {
+          Menu.item("A"),
+        },
+      })
+
+      local layout = Layout(
+        {
+          position = "50%",
+          size = "100%",
+        },
+        Layout.Box({
+          Layout.Box(menu, { size = "100%" }),
+        })
+      )
+
+      layout:mount()
+
+      h.assert_buf_lines(menu.bufnr, {
+        "A",
+      })
     end)
   end)
 end)


### PR DESCRIPTION
This PR resolves the following:

1. LuaLS warning: ```Missing required fields in type `nui_popup_internal`: `position`, `size`.```
2. Error when opening a Menu in a Layout without the `size` field.

Very new to the project so please let me know if there are specific unit tests I should update/add!

Error:
```
Error executing Lua callback: ...er/.local/share/nvim/lazy/nui.nvim/lua/nui/menu/init.lua:80: attempt to index field 'size' (a nil value)
stack traceback:
	...er/.local/share/nvim/lazy/nui.nvim/lua/nui/menu/init.lua:80: in function 'make_default_prepare_node'
	...er/.local/share/nvim/lazy/nui.nvim/lua/nui/menu/init.lua:286: in function 'init'
	.../.local/share/nvim/lazy/nui.nvim/lua/nui/object/init.lua:132: in function 'Menu'
	...uments/griptape/griptape.nvim/lua/griptape/structure.lua:19: in function 'run_structure'
	...r/Documents/griptape/griptape.nvim/lua/griptape/init.lua:7: in function <...r/Documents/griptape/griptape.nvim/lua/griptape/init.lua:6>
```

To reproduce:
```lua
local Menu = require("nui.menu")
local Layout = require("nui.layout")

local menu = Menu({
	border = {
		style = "rounded",
	},
}, {
	lines = {
		Menu.item("Hydrogen (H)"),
	},
})
local layout = Layout(
	{
		position = "50%",
		size = {
			width = 80,
			height = "60%",
		},
	},
	Layout.Box({
		Layout.Box(menu, { size = "100%" }),
	}, { dir = "row" })
)

layout:mount()
```