### PR TITLE
fix(split): manual doautocmd BufWinEnter for splits

### DIFF
--- a/lua/nui/split/init.lua
+++ b/lua/nui/split/init.lua
@@ -232,13 +232,19 @@ function Split:mount()
     group = self._.augroup.unmount,
     buffer = self.bufnr,
     callback = function()
-      autocmd.create("WinClosed", {
-        group = self._.augroup.hide,
-        pattern = tostring(self.winid),
-        callback = function()
-          self:hide()
-        end,
-      }, self.bufnr)
+      -- When two splits using the same buffer and both of them
+      -- are hiddden, calling `:show` for one of them fires
+      -- `BufWinEnter` for both of them. And in that scenario
+      -- one of them will not have `self.winid`.
+      if self.winid then
+        autocmd.create("WinClosed", {
+          group = self._.augroup.hide,
+          pattern = tostring(self.winid),
+          callback = function()
+            self:hide()
+          end,
+        }, self.bufnr)
+      end
     end,
   }, self.bufnr)
 


### PR DESCRIPTION
reference: https://github.com/MunifTanjim/nui.nvim/pull/197

The exact same thing (multiple hidden splits point to the same bufnr) can happen to `NuiSplit` as well.

I get the error message: _`Invalid 'group': 'nui_<id>_hide'`_ when I try to `split:show()`.

Hope this gets merged as soon as possible :)

Thanks in advance.

---

```txt
   Error  Error executing vim.schedule lua callback: /path/to/nui/split/init.lua:180: BufWinEnter Autocommands for "<buffer=10>": Vim(append):Error executing lua callback: /path/to/nui/split/init.lua:240: Invalid 'group': 'nui_2_hide'
stack traceback:
	[C]: in function 'create'
	/path/to/nui/split/init.lua:240: in function </path/to/nui/split/init.lua:234>
	[C]: in function 'nvim_win_set_buf'
	/path/to/nui/split/init.lua:180: in function '_open_window'
	/path/to/nui/split/init.lua:288: in function 'show'
	...neo-tree.nvim/lua/neo-tree/manager/init.lua:349: in function 'create_win'
	...neo-tree.nvim/lua/neo-tree/manager/init.lua:174: in function 'open_state'
	...neo-tree.nvim/lua/neo-tree/manager/init.lua:149: in function 'navigate'
	...neo-tree.nvim/lua/neo-tree/command/init.lua:59: in function <...neo-tree.nvim/lua/neo-tree/command/init.lua:58>
stack traceback:
	[C]: in function 'nvim_win_set_buf'
	/path/to/nui/split/init.lua:180: in function '_open_window'
	/path/to/nui/split/init.lua:288: in function 'show'
	...neo-tree.nvim/lua/neo-tree/manager/init.lua:349: in function 'create_win'
	...neo-tree.nvim/lua/neo-tree/manager/init.lua:174: in function 'open_state'
	...neo-tree.nvim/lua/neo-tree/manager/init.lua:149: in function 'navigate'
	...neo-tree.nvim/lua/neo-tree/command/init.lua:59: in function <...neo-tree.nvim/lua/neo-tree/command/init.lua:58>
```