### PR TITLE
fix(ci): fix tests using old nvim api

### DIFF
--- a/tests/nui/layout/init_spec.lua
+++ b/tests/nui/layout/init_spec.lua
@@ -51,15 +51,15 @@ local function get_assert_component(layout)
     end
 
     if border_win_config then
-      local border_row, border_col = border_win_config.row[vim.val_idx], border_win_config.col[vim.val_idx]
+      local border_row, border_col = border_win_config.row, border_win_config.col
       eq(border_row, expected.position.row)
       eq(border_col, expected.position.col)
 
-      local row, col = win_config.row[vim.val_idx], win_config.col[vim.val_idx]
+      local row, col = win_config.row, win_config.col
       eq(row, math.floor(component.border._.size_delta.width / 2 + 0.5))
       eq(col, math.floor(component.border._.size_delta.height / 2 + 0.5))
     else
-      local row, col = win_config.row[vim.val_idx], win_config.col[vim.val_idx]
+      local row, col = win_config.row, win_config.col
       eq(row, expected.position.row)
       eq(col, expected.position.col)
     end
@@ -482,8 +482,8 @@ describe("nui.layout", function()
 
         local win_config = vim.api.nvim_win_get_config(layout.winid)
         eq(win_config.relative, "win")
-        eq(win_config.row[vim.val_idx], 0)
-        eq(win_config.col[vim.val_idx], 0)
+        eq(win_config.row, 0)
+        eq(win_config.col, 0)
         eq(win_config.width, vim.o.columns)
         eq(win_config.height, 10)
 

--- a/tests/nui/popup/border_spec.lua
+++ b/tests/nui/popup/border_spec.lua
@@ -74,8 +74,8 @@ describe("nui.popup", function()
 
       local popup_win_config = vim.api.nvim_win_get_config(target_popup.winid)
       eq(popup_win_config.win, target_popup.border.winid)
-      eq(popup_win_config.row[vim.val_idx], border_char_size + padding.top)
-      eq(popup_win_config.col[vim.val_idx], border_char_size + padding.left)
+      eq(popup_win_config.row, border_char_size + padding.top)
+      eq(popup_win_config.col, border_char_size + padding.left)
 
       local border_win_config = vim.api.nvim_win_get_config(target_popup.border.winid)
       eq(border_win_config.width, popup_options.size.width + border_char_size * 2 + padding.right + padding.left)

--- a/tests/nui/popup/init_spec.lua
+++ b/tests/nui/popup/init_spec.lua
@@ -623,14 +623,14 @@ describe("nui.popup", function()
       local win_config = vim.api.nvim_win_get_config(popup.winid)
       eq(win_config.win, popup.border.winid or container_winid)
 
-      local row, col = win_config.row[vim.val_idx], win_config.col[vim.val_idx]
+      local row, col = win_config.row, win_config.col
 
       if popup.border.winid then
         eq(row, 1)
         eq(col, 1)
 
         local border_win_config = vim.api.nvim_win_get_config(popup.border.winid)
-        local border_row, border_col = border_win_config.row[vim.val_idx], border_win_config.col[vim.val_idx]
+        local border_row, border_col = border_win_config.row, border_win_config.col
         local border_width, border_height = border_win_config.width, border_win_config.height
 
         local delta_width = border_width - win_config.width


### PR DESCRIPTION
`vim.api.nvim_win_get_config` used to return a dict of numbers to represent a vim float number for `row` and `col` fields. This behavior was fixed in https://github.com/neovim/neovim/pull/27284 as a **breaking change** to the old API without any notice. Now user can refer to the value of `config.row` without indexing like `config.row[vim.val_idx]`.

This is the reason why tests are failing in https://github.com/MunifTanjim/nui.nvim/pull/332.