### PR TITLE
fix(split): always spawn split from current window when relative = editor

### DIFF
--- a/lua/nui/split/init.lua
+++ b/lua/nui/split/init.lua
@@ -165,7 +165,7 @@ function Split:_open_window()
     return
   end
 
-  self.winid = vim.api.nvim_win_call(self._.relative.win, function()
+  self.winid = vim.api.nvim_win_call(self._.relative.type == "editor" and 0 or self._.relative.win, function()
     vim.api.nvim_command(
       string.format(
         "silent noswapfile %s %ssplit",

--- a/tests/nui/split/init_spec.lua
+++ b/tests/nui/split/init_spec.lua
@@ -163,6 +163,29 @@ describe("nui.split", function()
       left_half_split:unmount()
     end)
 
+    it("'editor' is not tied to specific window", function()
+      local center_split = Split({
+        size = 20,
+        position = "right",
+      })
+
+      center_split:mount()
+
+      split = Split({
+        size = 20,
+        position = "right",
+        relative = "editor",
+      })
+
+      split:mount()
+
+      center_split:unmount()
+
+      split:hide()
+
+      split:show()
+    end)
+
     it("supports 'win'", function()
       local left_half_split = Split({
         size = "50%",


### PR DESCRIPTION
https://github.com/MunifTanjim/nui.nvim/discussions/335

> [!WARNING]
> 
> I haven't added any tests and I don't know how to work with the test suite.
> It would be nice if you @MunifTanjim could make a followup PR if you want to add some tests.