### PR TITLE
fix(popup): always use current window when position == "cursor"

### DIFF
--- a/lua/nui/layout/utils.lua
+++ b/lua/nui/layout/utils.lua
@@ -89,7 +89,7 @@ function mod.get_container_info(position)
 
   return {
     relative = position.bufpos and "buf" or relative,
-    size = utils.get_window_size(position.win),
+    size = utils.get_window_size(relative == "cursor" and 0 or position.win),
     type = "window",
   }
 end

--- a/lua/nui/layout/utils.lua
+++ b/lua/nui/layout/utils.lua
@@ -137,7 +137,9 @@ function mod.update_layout_config(component_internal, config)
   if options.relative then
     internal.layout.relative = options.relative
 
-    local fallback_winid = internal.position and internal.position.win or vim.api.nvim_get_current_win()
+    local fallback_winid = internal.position and internal.position.win
+      or internal.layout.relative.type ~= "win" and 0
+      or vim.api.nvim_get_current_win()
     internal.position =
       vim.tbl_extend("force", internal.position or {}, mod.parse_relative(internal.layout.relative, fallback_winid))
 

--- a/lua/nui/layout/utils.lua
+++ b/lua/nui/layout/utils.lua
@@ -138,7 +138,7 @@ function mod.update_layout_config(component_internal, config)
     internal.layout.relative = options.relative
 
     local fallback_winid = internal.position and internal.position.win
-      or internal.layout.relative.type ~= "win" and 0
+      or internal.layout.relative.type == "cursor" and 0
       or vim.api.nvim_get_current_win()
     internal.position =
       vim.tbl_extend("force", internal.position or {}, mod.parse_relative(internal.layout.relative, fallback_winid))

--- a/lua/nui/layout/utils.lua
+++ b/lua/nui/layout/utils.lua
@@ -89,7 +89,7 @@ function mod.get_container_info(position)
 
   return {
     relative = position.bufpos and "buf" or relative,
-    size = utils.get_window_size(relative == "cursor" and 0 or position.win),
+    size = utils.get_window_size(position.win),
     type = "window",
   }
 end


### PR DESCRIPTION
Fixes https://github.com/folke/noice.nvim/issues/636.

There are many ways to fix this issue, but I think my approach is the cleanest.

Other options:

- Overwrite `internal.position.win` to nil just like `win_config.win` here. (`win_config.win` will be nil, but `internal.position.win` is still unchanged and remembers the old value.)
https://github.com/MunifTanjim/nui.nvim/blob/c3c7fd618dcb5a89e443a2e1033e7d11fdb0596b/lua/nui/layout/utils.lua#L145
- Pass `win_config` instead of `internal.position` to `mod.get_container_info` here.
https://github.com/MunifTanjim/nui.nvim/blob/c3c7fd618dcb5a89e443a2e1033e7d11fdb0596b/lua/nui/layout/utils.lua#L156

Basically we need to pass a table with `win = nil` to `get_window_size()` that is called inside `get_container_info`, or deal with invalid `table.win` and ignore that value inside that function.

> [!NOTE]
> It might be better to `relative ~= "win" and 0 or position.win`?
>
> Basically the values are `relative = "editor"|"win"|"cursor"`, and "editor" case is dealt with above, so they mean the exact same thing for now, but may not be in the future (when new position value is added).