### PR TITLE
fix(popup): mimic native 'solid' border

### DIFF
--- a/lua/nui/popup/border.lua
+++ b/lua/nui/popup/border.lua
@@ -250,7 +250,7 @@ local styles = {
   rounded = to_border_map({ "╭", "─", "╮", "│", "╯", "─", "╰", "│" }),
   shadow = "shadow",
   single = to_border_map({ "┌", "─", "┐", "│", "┘", "─", "└", "│" }),
-  solid = to_border_map({ "▛", "▀", "▜", "▐", "▟", "▄", "▙", "▌" }),
+  solid = to_border_map({ " ", " ", " ", " ", " ", " ", " ", " " }),
 }
 
 ---@param style nui_popup_border_option_style


### PR DESCRIPTION
for previous behavior:

```lua
  border = {
    style = { "▛", "▀", "▜", "▐", "▟", "▄", "▙", "▌" },
  },
```

---

resolves #351 