### PR TITLE
fix(input): add missing `winid`

### DIFF
--- a/lua/nui/layout/utils.lua
+++ b/lua/nui/layout/utils.lua
@@ -78,12 +78,14 @@ end
 ---@return nui_layout_container_info
 function mod.get_container_info(position)
   local relative = position.relative
+  local winid = position.win == 0 and vim.api.nvim_get_current_win() or position.win
 
   if relative == "editor" then
     return {
       relative = relative,
       size = utils.get_editor_size(),
       type = "editor",
+      winid = winid,
     }
   end
 
@@ -91,7 +93,7 @@ function mod.get_container_info(position)
     relative = position.bufpos and "buf" or relative,
     size = utils.get_window_size(position.win),
     type = "window",
-    winid = position.win == 0 and vim.api.nvim_get_current_win() or position.win,
+    winid = winid,
   }
 end
 


### PR DESCRIPTION
ref: https://github.com/kawre/leetcode.nvim/issues/95

`mod.get_container_info` is missing winid if container is relative to editor