### PR TITLE
fix(popup): guard against invalid winid

### DIFF
--- a/lua/nui/layout/init.lua
+++ b/lua/nui/layout/init.lua
@@ -267,11 +267,7 @@ function Layout:_open_window()
 end
 
 function Layout:_close_window()
-  if not self.winid then
-    return
-  end
-
-  if vim.api.nvim_win_is_valid(self.winid) then
+  if _.is_window_valid(self.winid) then
     vim.api.nvim_win_close(self.winid, true)
   end
 
@@ -437,7 +433,7 @@ function Layout:update(config, box)
 
     u.update_layout_config(info, config)
 
-    if self.winid then
+    if _.is_window_valid(self.winid) then
       vim.api.nvim_win_set_config(self.winid, info.win_config)
 
       self:_process_layout()

--- a/lua/nui/popup/border.lua
+++ b/lua/nui/popup/border.lua
@@ -496,7 +496,7 @@ function Border:init(popup, options)
 end
 
 function Border:_open_window()
-  if self.winid or not self.bufnr then
+  if _.is_window_valid(self.winid) or not self.bufnr then
     return
   end
 
@@ -519,11 +519,7 @@ function Border:_open_window()
 end
 
 function Border:_close_window()
-  if not self.winid then
-    return
-  end
-
-  if vim.api.nvim_win_is_valid(self.winid) then
+  if _.is_window_valid(self.winid) then
     vim.api.nvim_win_close(self.winid, true)
   end
 
@@ -615,7 +611,7 @@ function Border:_relayout(size_only)
 
   internal.lines = calculate_buf_lines(internal)
 
-  if self.winid then
+  if _.is_window_valid(self.winid) then
     if size_only and old_row == self.win_config.row and old_col == self.win_config.col then
       -- Only size got updated, so let's not reposition the border
       vim.api.nvim_win_set_config(self.winid, {
@@ -675,12 +671,12 @@ function Border:set_highlight(highlight)
   local winhighlight_data = _.parse_winhighlight(self.popup._.win_options.winhighlight)
   winhighlight_data["FloatBorder"] = highlight
   self.popup._.win_options.winhighlight = _.serialize_winhighlight(winhighlight_data)
-  if self.popup.winid then
+  if _.is_window_valid(self.popup.winid) then
     _.set_win_option(self.popup.winid, "winhighlight", self.popup._.win_options.winhighlight)
   end
 
   internal.winhighlight = calculate_winhighlight(internal, self.popup._.win_options.winhighlight)
-  if self.winid then
+  if _.is_window_valid(self.winid) then
     _.set_win_option(self.winid, "winhighlight", internal.winhighlight)
   end
 end

--- a/lua/nui/popup/init.lua
+++ b/lua/nui/popup/init.lua
@@ -160,7 +160,7 @@ function Popup:init(options)
 end
 
 function Popup:_open_window()
-  if self.winid or not self.bufnr then
+  if _.is_window_valid(self.winid) or not self.bufnr then
     return
   end
 
@@ -181,11 +181,7 @@ function Popup:_open_window()
 end
 
 function Popup:_close_window()
-  if not self.winid then
-    return
-  end
-
-  if vim.api.nvim_win_is_valid(self.winid) then
+  if _.is_window_valid(self.winid) then
     vim.api.nvim_win_close(self.winid, true)
   end
 
@@ -396,7 +392,7 @@ function Popup:update_layout(config)
 
   self._.layout_ready = true
 
-  if self.winid then
+  if _.is_window_valid(self.winid) then
     if size_only and old_row == self.win_config.row and old_col == self.win_config.col then
       -- Only size got updated, so let's not reposition the popup
       vim.api.nvim_win_set_config(self.winid, {

--- a/lua/nui/utils/init.lua
+++ b/lua/nui/utils/init.lua
@@ -32,6 +32,13 @@ function utils.get_window_size(winid)
   }
 end
 
+---@param winid? integer
+---@return boolean
+function _.is_window_valid(winid)
+  -- a non-nil `winid` does not mean the window still exists
+  return winid ~= nil and vim.api.nvim_win_is_valid(winid)
+end
+
 function utils.defaults(v, default_value)
   return type(v) == "nil" and default_value or v
 end

--- a/tests/nui/popup/init_spec.lua
+++ b/tests/nui/popup/init_spec.lua
@@ -1224,6 +1224,37 @@ describe("nui.popup", function()
       eq(#curr_winids, #vim.api.nvim_list_wins())
     end)
 
+    it("reopens windows when winid is stale (non-nil but invalid)", function()
+      popup = Popup({
+        border = {
+          style = "single",
+          padding = { 0 },
+        },
+        position = 0,
+        size = 10,
+      })
+
+      popup:mount()
+
+      local winid, border_winid = popup.winid, popup.border.winid
+      eq(type(winid), "number")
+      eq(type(border_winid), "number")
+
+      popup:hide()
+
+      -- simulate stale winids: non-nil, but pointing to closed windows
+      popup.winid, popup.border.winid = winid, border_winid
+      eq(vim.api.nvim_win_is_valid(popup.winid), false)
+      eq(vim.api.nvim_win_is_valid(popup.border.winid), false)
+
+      popup:show()
+
+      eq(vim.api.nvim_win_is_valid(popup.winid), true)
+      eq(vim.api.nvim_win_is_valid(popup.border.winid), true)
+      eq(winid ~= popup.winid, true)
+      eq(border_winid ~= popup.border.winid, true)
+    end)
+
     it("mounts if not mounted", function()
       popup = Popup({
         position = 0,


### PR DESCRIPTION
winid is not nil, not meaning it is valid.