### PR TITLE
Add 'on_mount' option to menu

### DIFF
--- a/lua/nui/menu/README.md
+++ b/lua/nui/menu/README.md
@@ -199,7 +199,7 @@ Callback function, called when menu is submitted.
 
 **Type:** `function`
 
-_Signature:_ `on_mount(item) -> nil`
+_Signature:_ `on_mount() -> nil`
 
 Callback function, called when menu is mounted.
 

--- a/lua/nui/menu/README.md
+++ b/lua/nui/menu/README.md
@@ -49,6 +49,10 @@ local menu = Menu(popup_options, {
   on_submit = function(item)
     print("SUBMITTED", vim.inspect(item))
   end,
+  on_mount = function()
+    print("MOUNTED")
+  end
+
 })
 ```
 
@@ -190,6 +194,14 @@ Callback function, called when menu is closed.
 _Signature:_ `on_submit(item) -> nil`
 
 Callback function, called when menu is submitted.
+
+### `on_mount`
+
+**Type:** `function`
+
+_Signature:_ `on_mount(item) -> nil`
+
+Callback function, called when menu is mounted.
 
 ## Methods
 

--- a/lua/nui/menu/init.lua
+++ b/lua/nui/menu/init.lua
@@ -203,6 +203,7 @@ end
 ---@field on_change? fun(item: NuiTree.Node, menu: NuiMenu): nil
 ---@field on_close? fun(): nil
 ---@field on_submit? fun(item: NuiTree.Node): nil
+---@field on_mount? fun(): nil
 
 ---@class NuiMenu: NuiPopup
 ---@field private _ nui_menu_internal

--- a/lua/nui/menu/init.lua
+++ b/lua/nui/menu/init.lua
@@ -119,7 +119,7 @@ local function make_default_prepare_node(menu)
       end
 
       local left_gap_width, right_gap_width =
-        _.calculate_gap_width(defaults(sep_text_align, "center"), sep_max_width, content:width())
+          _.calculate_gap_width(defaults(sep_text_align, "center"), sep_max_width, content:width())
 
       local line = Line()
 
@@ -327,6 +327,10 @@ function Menu:mount()
   Menu.super.mount(self)
 
   local props = self.menu_props
+
+  if props.on_mount then
+    props.on_mount(self)
+  end
 
   for _, key in pairs(self._.keymap.focus_next) do
     self:map("n", key, props.on_focus_next, { noremap = true, nowait = true })

--- a/lua/nui/menu/init.lua
+++ b/lua/nui/menu/init.lua
@@ -279,6 +279,7 @@ function Menu:init(popup_options, options)
     end
   end
 
+
   ---@deprecated
   self._.sep = options.separator
 
@@ -288,6 +289,12 @@ function Menu:init(popup_options, options)
   self.menu_props = {}
 
   local props = self.menu_props
+
+  props.on_mount = function()
+    if options.on_mount then
+      options.on_mount()
+    end
+  end
 
   props.on_submit = function()
     local item = self.tree:get_node()
@@ -329,7 +336,7 @@ function Menu:mount()
   local props = self.menu_props
 
   if props.on_mount then
-    props.on_mount(self)
+    props.on_mount()
   end
 
   for _, key in pairs(self._.keymap.focus_next) do


### PR DESCRIPTION
**Changes:**
- Added the `on_mount` option to the menu module.
- Updated the relevant documentation to include the new option.

**Usage:**
Users can now pass an `on_mount` function when creating a menu to execute custom code when the menu is mounted. Example usage:
```lua
local Menu = require('nui.menu')

local menu = Menu({
    ...
    on_mount = function()
        print("Menu mounted!")
    end,
    -- other menu options
})