### PR TITLE
Popup: Don't reposition if only size has changed

### DIFF
--- a/lua/nui/popup/border.lua
+++ b/lua/nui/popup/border.lua
@@ -584,12 +584,16 @@ function Border:unmount()
   self:_close_window()
 end
 
-function Border:_relayout()
+---@param size_only? boolean
+function Border:_relayout(size_only)
   local internal = self._
 
   if internal.type ~= "complex" then
     return
   end
+
+  local old_row = self.win_config.row
+  local old_col = self.win_config.col
 
   if self.popup.win_config.anchor and self.popup.win_config.anchor ~= self.win_config.anchor then
     self.win_config.anchor = self.popup.win_config.anchor
@@ -612,7 +616,15 @@ function Border:_relayout()
   internal.lines = calculate_buf_lines(internal)
 
   if self.winid then
-    vim.api.nvim_win_set_config(self.winid, self.win_config)
+    if size_only and old_row == self.win_config.row and old_col == self.win_config.col then
+      -- Only size got updated, so let's not reposition the border
+      vim.api.nvim_win_set_config(self.winid, {
+        width = self.win_config.width,
+        height = self.win_config.height,
+      })
+    else
+      vim.api.nvim_win_set_config(self.winid, self.win_config)
+    end
   end
 
   if self.bufnr then

--- a/lua/nui/popup/init.lua
+++ b/lua/nui/popup/init.lua
@@ -385,19 +385,33 @@ end
 function Popup:update_layout(config)
   config = config or {}
 
+  local size_only = config.size ~= nil and vim.tbl_count(config) == 1
+
+  local old_row = self.win_config.row
+  local old_col = self.win_config.col
+
   u.update_layout_config(self._, config)
 
-  self.border:_relayout()
+  self.border:_relayout(size_only)
 
   self._.layout_ready = true
 
   if self.winid then
-    -- upstream issue: https://github.com/neovim/neovim/issues/20370
-    local win_config_style = self.win_config.style
-    ---@diagnostic disable-next-line: assign-type-mismatch
-    self.win_config.style = ""
-    vim.api.nvim_win_set_config(self.winid, self.win_config)
-    self.win_config.style = win_config_style
+    if size_only and old_row == self.win_config.row and old_col == self.win_config.col then
+      -- Only size got updated, so let's not reposition the popup
+      vim.api.nvim_win_set_config(self.winid, {
+        style = "", -- https://github.com/neovim/neovim/issues/20370
+        width = self.win_config.width,
+        height = self.win_config.height,
+      })
+    else
+      -- https://github.com/neovim/neovim/issues/20370
+      local win_config_style = self.win_config.style
+      ---@diagnostic disable-next-line: assign-type-mismatch
+      self.win_config.style = ""
+      vim.api.nvim_win_set_config(self.winid, self.win_config)
+      self.win_config.style = win_config_style
+    end
   end
 end
 

--- a/tests/nui/popup/init_spec.lua
+++ b/tests/nui/popup/init_spec.lua
@@ -769,6 +769,83 @@ describe("nui.popup", function()
       }, popup.border.bufnr, hl_group)
     end)
 
+    it("does not reposition on size-only update (w/o border)", function()
+      vim.api.nvim_buf_set_lines(vim.api.nvim_get_current_buf(), 0, -1, false, {
+        "line 1",
+        "line 2",
+        "line 3",
+        "line 4",
+        "line 5",
+        "line 6",
+        "line 7",
+        "line 8",
+        "line 9",
+        "line 10",
+      })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      popup = Popup({
+        relative = "cursor",
+        position = { row = 1, col = 1 },
+        size = { width = 4, height = 2 },
+      })
+
+      popup:mount()
+
+      eq(type(popup.border.winid), "nil")
+
+      local popup_pos = vim.api.nvim_win_get_position(popup.winid)
+
+      -- move the cursor; a size-only update must not re-anchor to it
+      vim.api.nvim_win_set_cursor(0, { 5, 0 })
+
+      local new_size = { width = 8, height = 4 }
+      popup:update_layout({ size = new_size })
+
+      assert_size(popup, new_size)
+      eq(vim.api.nvim_win_get_position(popup.winid), popup_pos)
+    end)
+
+    it("does not reposition on size-only update (w/ complex border)", function()
+      vim.api.nvim_buf_set_lines(vim.api.nvim_get_current_buf(), 0, -1, false, {
+        "line 1",
+        "line 2",
+        "line 3",
+        "line 4",
+        "line 5",
+        "line 6",
+        "line 7",
+        "line 8",
+        "line 9",
+        "line 10",
+      })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      popup = Popup({
+        relative = "cursor",
+        border = { style = "single", padding = { 0 } },
+        position = { row = 1, col = 1 },
+        size = { width = 4, height = 2 },
+      })
+
+      popup:mount()
+
+      eq(type(popup.border.winid), "number")
+
+      local border_pos = vim.api.nvim_win_get_position(popup.border.winid)
+      local popup_pos = vim.api.nvim_win_get_position(popup.winid)
+
+      -- move the cursor; a size-only update must not re-anchor to it
+      vim.api.nvim_win_set_cursor(0, { 5, 0 })
+
+      local new_size = { width = 8, height = 4 }
+      popup:update_layout({ size = new_size })
+
+      assert_size(popup, new_size, true)
+      eq(vim.api.nvim_win_get_position(popup.border.winid), border_pos)
+      eq(vim.api.nvim_win_get_position(popup.winid), popup_pos)
+    end)
+
     it("can change position (w/ simple border)", function()
       local position = {
         row = 0,


### PR DESCRIPTION
Currently there is no way to resize the popup without causing repositioning. So changing only the size of a popup that's positioned relative to cursor position, will cause it to move to potentially new cursor position.

So this is an attempt to update only the size of the window if position related properties have not changed during the relayout.