### PR TITLE
chore: fix variable misstype in input/README.md

### DIFF
--- a/lua/nui/input/README.md
+++ b/lua/nui/input/README.md
@@ -57,7 +57,7 @@ end, { noremap = true })
 ```
 
 You can manipulate the associated buffer and window using the
-`split.bufnr` and `split.winid` properties.
+`input.bufnr` and `input.winid` properties.
 
 **NOTE**: the first argument accepts options for `nui.popup` component.
 


### PR DESCRIPTION
variable name changed from 'split' to 'input'