### PR TITLE
Input: Fix default text not being set when input doesnt immediately get focus

### DIFF
--- a/lua/nui/input/init.lua
+++ b/lua/nui/input/init.lua
@@ -115,11 +115,13 @@ function Input:mount()
     vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, { self._.prompt:content() .. self._.default_value })
   end
 
-  if self._.prompt:length() > 0 then
-    vim.schedule(function()
-      self._.prompt:highlight(self.bufnr, self.ns_id, 1, 0)
-    end)
-  end
+  self:on(event.InsertEnter, function()
+    if self._.prompt:length() > 0 then
+      vim.schedule(function()
+        self._.prompt:highlight(self.bufnr, self.ns_id, 1, 0)
+      end)
+    end
+  end, { once = true })
 
   vim.api.nvim_command("startinsert!")
 end

--- a/lua/nui/input/init.lua
+++ b/lua/nui/input/init.lua
@@ -111,17 +111,17 @@ function Input:mount()
 
   vim.fn.prompt_setprompt(self.bufnr, self._.prompt:content())
 
-  self:on(event.InsertEnter, function()
-    if #self._.default_value then
-      vim.api.nvim_feedkeys(self._.default_value, "n", true)
-    end
+  
+  if #self._.default_value then
+    vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, { self._.prompt .. self._.default_value})
+  end
 
-    if self._.prompt:length() > 0 then
-      vim.schedule(function()
-        self._.prompt:highlight(self.bufnr, self.ns_id, 1, 0)
-      end)
-    end
-  end, { once = true })
+  if self._.prompt:length() > 0 then
+    vim.schedule(function()
+      self._.prompt:highlight(self.bufnr, self.ns_id, 1, 0)
+    end)
+  end
+
 
   vim.api.nvim_command("startinsert!")
 end

--- a/lua/nui/input/init.lua
+++ b/lua/nui/input/init.lua
@@ -111,9 +111,8 @@ function Input:mount()
 
   vim.fn.prompt_setprompt(self.bufnr, self._.prompt:content())
 
-  
   if #self._.default_value then
-    vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, { self._.prompt .. self._.default_value})
+    vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, { self._.prompt:content() .. self._.default_value })
   end
 
   if self._.prompt:length() > 0 then
@@ -121,7 +120,6 @@ function Input:mount()
       self._.prompt:highlight(self.bufnr, self.ns_id, 1, 0)
     end)
   end
-
 
   vim.api.nvim_command("startinsert!")
 end

--- a/lua/nui/input/init.lua
+++ b/lua/nui/input/init.lua
@@ -44,7 +44,7 @@ local Input = Popup:extend("NuiInput")
 ---@param popup_options nui_popup_options
 ---@param options nui_input_options
 function Input:init(popup_options, options)
-  popup_options.enter = true
+  popup_options.enter = false
 
   popup_options.buf_options = defaults(popup_options.buf_options, {})
   popup_options.buf_options.buftype = "prompt"
@@ -77,6 +77,24 @@ function Input:mount()
     return
   end
 
+  vim.fn.prompt_setprompt(self.bufnr, self._.prompt:content())
+
+  if #self._.default_value > 0 then
+    vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, { self._.prompt:content() .. self._.default_value })
+  end
+
+  self:on(event.BufWinEnter, function()
+    vim.schedule(function()
+      if self._.prompt:length() > 0 then
+        self._.prompt:highlight(self.bufnr, self.ns_id, 1, 0)
+      end
+
+      vim.api.nvim_set_current_win(self.winid)
+    end)
+
+    vim.api.nvim_command("startinsert!")
+  end, { once = false })
+
   Input.super.mount(self)
 
   if self._.on_change then
@@ -108,22 +126,6 @@ function Input:mount()
   end
 
   vim.fn.prompt_setinterrupt(self.bufnr, props.on_close)
-
-  vim.fn.prompt_setprompt(self.bufnr, self._.prompt:content())
-
-  if #self._.default_value then
-    vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, { self._.prompt:content() .. self._.default_value })
-  end
-
-  self:on(event.InsertEnter, function()
-    if self._.prompt:length() > 0 then
-      vim.schedule(function()
-        self._.prompt:highlight(self.bufnr, self.ns_id, 1, 0)
-      end)
-    end
-  end, { once = true })
-
-  vim.api.nvim_command("startinsert!")
 end
 
 function Input:unmount()

--- a/lua/nui/input/init.lua
+++ b/lua/nui/input/init.lua
@@ -79,9 +79,7 @@ function Input:mount()
 
   vim.fn.prompt_setprompt(self.bufnr, self._.prompt:content())
 
-  if #self._.default_value > 0 then
-    vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, { self._.prompt:content() .. self._.default_value })
-  end
+  vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, { self._.prompt:content() .. self._.default_value })
 
   self:on(event.BufWinEnter, function()
     vim.schedule(function()

--- a/tests/nui/input/init_spec.lua
+++ b/tests/nui/input/init_spec.lua
@@ -42,6 +42,7 @@ describe("nui.input", function()
       })
 
       input:mount()
+      vim.wait(100, function() end)
 
       h.assert_buf_lines(input.bufnr, {
         prompt_text,
@@ -66,6 +67,7 @@ describe("nui.input", function()
       })
 
       input:mount()
+      vim.wait(100, function() end)
 
       feedkeys("aa", "x") -- append a
       feedkeys("ab", "x") -- append b
@@ -90,6 +92,7 @@ describe("nui.input", function()
       })
 
       input:mount()
+      vim.wait(100, function() end)
 
       feedkeys("i<C-c>", "x")
 
@@ -110,6 +113,8 @@ describe("nui.input", function()
       })
 
       input:mount()
+      vim.wait(100, function() end)
+
       input:unmount()
 
       vim.fn.wait(200, function()
@@ -144,6 +149,7 @@ describe("nui.input", function()
       })
 
       input:mount()
+      vim.wait(100, function() end)
 
       feedkeys("<cr>", "x")
 
@@ -166,6 +172,7 @@ describe("nui.input", function()
       })
 
       input:mount()
+      vim.wait(100, function() end)
 
       feedkeys("<esc><cr>", "x")
 
@@ -188,6 +195,7 @@ describe("nui.input", function()
       })
 
       input:mount()
+      vim.wait(100, function() end)
 
       input:map("i", "<esc>", function()
         input:unmount()
@@ -214,6 +222,7 @@ describe("nui.input", function()
       })
 
       input:mount()
+      vim.wait(100, function() end)
 
       input:map("n", "<esc>", function()
         input:unmount()
@@ -235,6 +244,7 @@ describe("nui.input", function()
       input = Input(popup_options, {})
 
       input:mount()
+      vim.wait(100, function() end)
 
       local bufnr, winid = input.bufnr, input.winid
 
@@ -259,6 +269,8 @@ describe("nui.input", function()
       })
 
       input:mount()
+      vim.wait(100, function() end)
+
       input:unmount()
       input:unmount()
       input:unmount()


### PR DESCRIPTION
Basically, I had this issue where I had a Layout consisting of 3 Inputs, all of which had default texts. However only the last Input (The one that received focus) Would set its own default text. That was an issue for me. So I fixed it.

## Potential issues
- I havent tested this with prompts much