### PR TITLE
fix: adjust error message text for duplicate node

### DIFF
--- a/lua/nui/tree/init.lua
+++ b/lua/nui/tree/init.lua
@@ -33,7 +33,7 @@ local function initialize_nodes(nodes, parent_node, get_node_id)
     local node_id = node:get_id()
 
     if by_id[node_id] then
-      error("duplicate node id" .. node_id)
+      error("duplicate node id " .. node_id)
     end
 
     by_id[node_id] = node


### PR DESCRIPTION
This is really small change, but I was blind enough and spend hours of debugging because I could not find the node with "idXY" :). 