### PR TITLE
fix(popup): explicitly remove inner border when border is complex

### DIFF
--- a/lua/nui/popup/border.lua
+++ b/lua/nui/popup/border.lua
@@ -7,6 +7,7 @@ local _ = require("nui.utils")._
 local is_type = require("nui.utils").is_type
 
 local has_nvim_0_5_1 = vim.fn.has("nvim-0.5.1") == 1
+local has_nvim_0_11_0 = vim.fn.has("nvim-0.11.0") == 1
 
 local index_name = {
   "top_left",
@@ -717,6 +718,9 @@ function Border:get()
   local internal = self._
 
   if internal.type ~= "simple" then
+    if has_nvim_0_11_0 then
+      return "none"
+    end
     return nil
   end
 


### PR DESCRIPTION
On neovim v0.11, there's a `'winborder'` option which dictates what the default border of a floating window should be. This breaks nui popups (such as NuiInput) w/ non-simple borders since they open 2 windows - one for the inner window, and one for the border, and both windows would show borders if `winborder ~= 'none'|''` (instead of the expected behavior where only the border window has the border)

To resolve this, the inner window should explicitly resolve to its border to "none" instead of nil when a complex border is used.