### PR TITLE
fix copy-paste typo in menu documentation

### DIFF
--- a/lua/nui/menu/README.md
+++ b/lua/nui/menu/README.md
@@ -53,7 +53,7 @@ local menu = Menu(popup_options, {
 ```
 
 You can manipulate the associated buffer and window using the
-`split.bufnr` and `split.winid` properties.
+`menu.bufnr` and `menu.winid` properties.
 
 **NOTE**: the first argument accepts options for `nui.popup` component.
 


### PR DESCRIPTION
That line seems to have been copied without modification from the documentation of the split component.