### PR TITLE
feat(table): borderless tables, dynamic data, and cross-grid cell navigation

### DIFF
--- a/lua/nui/table/README.md
+++ b/lua/nui/table/README.md
@@ -74,11 +74,60 @@ List of `NuiTable.ColumnDef` objects.
 
 List of data items.
 
+---
+
+### `border`
+
+**Type:** `'none'` or `table<string, string>` (optional)
+
+Border characters to use, merged over the defaults (single-line box-drawing).
+The customizable slots are `hor`, `ver`, `down_right`, `down_hor`, `down_left`,
+`ver_right`, `ver_hor`, `ver_left`, `up_right`, `up_hor`, `up_left`.
+
+Pass `'none'` for a **borderless** table: no horizontal border lines are drawn
+and columns are separated by a single space.
+
+---
+
+### `buf_options`
+
+**Type:** `table<string, any>` (optional)
+
+Buffer options to set, merged over the scratch-buffer defaults.
+
 ## Methods
+
+### `tbl:set_data`
+
+_Signature:_ `tbl:set_data(data: any[]) -> NuiTable`
+
+Replaces the table's data. Does not render; call `tbl:render()` afterwards.
+Returns the table for chaining.
+
+**Parameters**
+
+| Name   | Type    | Description         |
+| ------ | ------- | ------------------ |
+| `data` | `any[]` | List of data items |
+
+### `tbl:get_size`
+
+_Signature:_ `tbl:get_size() -> { width: integer, height: integer } | nil`
+
+Returns the dimensions (in cells) of the most recent render, or `nil` if the
+table has not been rendered yet.
 
 ### `tbl:get_cell`
 
-_Signature:_ `tbl:get_cell(position?: {integer, integer}) -> NuiTable.Cell | nil`
+_Signature:_ `tbl:get_cell(position?: {integer, integer}) -> NuiTable.Cell | NuiTable.HeaderCell | nil`
+
+Returns the cell relative to the one under the cursor, over the continuous
+header + data + footer grid. Returns `nil` past the grid edges or when the
+cursor isn't on a cell.
+
+The returned value carries a `type` field: `NuiTable.Cell` (data cells) has
+`type = "data"`; `NuiTable.HeaderCell` (header/footer cells) has
+`type = "header"` or `"footer"`.
 
 **Parameters**
 
@@ -86,7 +135,26 @@ _Signature:_ `tbl:get_cell(position?: {integer, integer}) -> NuiTable.Cell | nil
 | ---------- | ---------------------- | ------------------------------------- |
 | `position` | `{ integer, integer }` | `(row, col)` tuple relative to cursor |
 
-Returns the `NuiTable.Cell` if found.
+Vertical moves (`row`) keep the cursor's column; horizontal moves (`col`) step
+cell-by-cell. When a vertical move lands on a border, it biases to the cell on
+its right.
+
+### `tbl:goto_cell`
+
+_Signature:_ `tbl:goto_cell(position?: {integer, integer}) -> NuiTable.Cell | NuiTable.HeaderCell | nil`
+
+Like `get_cell`, but also moves the cursor to the resolved cell: vertical moves
+keep the cursor's column, horizontal moves snap to the target cell's content.
+No-op (returns `nil`) if there's no cell there (e.g. at a grid edge). With no
+`position`, it snaps the cursor to the current cell.
+
+**Parameters**
+
+| Name       | Type                   | Description                           |
+| ---------- | ---------------------- | ------------------------------------- |
+| `position` | `{ integer, integer }` | `(row, col)` tuple relative to cursor |
+
+Returns the cell the cursor was moved to, if any.
 
 ### `tbl:refresh_cell`
 

--- a/lua/nui/table/init.lua
+++ b/lua/nui/table/init.lua
@@ -5,7 +5,7 @@ local _ = require("nui.utils")._
 
 -- luacheck: push no max comment line length
 
----@alias nui_table_border_char_name 'down_right'|'hor'|'down_hor'|'down_left'|'ver'|'ver_left'|'ver_hor'|'ver_left'|'up_right'|'up_hor'|'up_left'
+---@alias nui_table_border_char_name 'down_right'|'hor'|'down_hor'|'down_left'|'ver'|'ver_right'|'ver_hor'|'ver_left'|'up_right'|'up_hor'|'up_left'
 
 ---@alias _nui_table_header_kind
 ---| -1 -- footer
@@ -88,8 +88,21 @@ local function prepare_columns(internal, columns, parent, depth)
       col.align = "left"
     end
 
-    if not col.width then
-      col.width = 0
+    -- an explicit width makes the column fixed (content is truncated to it).
+    -- without it, the column flexes to fit content (respecting min/max_width).
+    col._fixed_width = col.width
+    col.width = col.width or col.min_width or 0
+  end
+end
+
+---@param columns NuiTable.ColumnDef[]
+local function reset_column_widths(columns)
+  for _, col in ipairs(columns) do
+    -- fixed columns keep their width; flexible ones are recomputed from
+    -- content before each render, starting from their min_width floor.
+    col.width = col._fixed_width or col.min_width or 0
+    if col.columns then
+      reset_column_widths(col.columns)
     end
   end
 end
@@ -106,6 +119,7 @@ end
 ---@field max_width? integer
 ---@field min_width? integer
 ---@field width? integer
+---@field _fixed_width? integer -- (private) configured fixed width; nil means the column flexes to content
 
 ---@class NuiTable.Column
 ---@field accessor_fn? fun(original_row: table, index: integer): string|NuiText|NuiLine
@@ -116,6 +130,9 @@ end
 ---@field id string
 ---@field parent? NuiTable.Column
 ---@field width integer
+---@field max_width? integer
+---@field min_width? integer
+---@field _fixed_width? integer -- (private) configured fixed width; nil means the column flexes to content
 
 ---@class NuiTable.Row
 ---@field id string
@@ -123,14 +140,24 @@ end
 ---@field original table
 
 ---@class NuiTable.Cell
+---@field type 'data'
 ---@field column NuiTable.Column
 ---@field content NuiText|NuiLine
 ---@field get_value fun(): string|NuiText|NuiLine
 ---@field row NuiTable.Row
 ---@field range table<1|2|3|4, integer> -- [start_row, start_col, end_row, end_col]
 
+---@class NuiTable.HeaderCell
+---@field type 'header'|'footer'
+---@field column NuiTable.Column
+---@field content NuiText|NuiLine
+---@field col_span integer
+---@field row_span integer
+---@field range table<1|2|3|4, integer> -- [start_row, start_col, end_row, end_col]
+
 ---@class nui_table_internal
 ---@field border table
+---@field has_border boolean
 ---@field buf_options table<string, any>
 ---@field headers NuiTable.Column[]|{ depth: integer }
 ---@field columns NuiTable.ColumnDef[]
@@ -138,14 +165,17 @@ end
 ---@field has_header boolean
 ---@field has_footer boolean
 ---@field linenr table<1|2, integer>
----@field data_linenrs integer[]
----@field data_grid nui_t_list<NuiTable.Cell[]>
+---@field line_cells table<integer, (NuiTable.Cell|NuiTable.HeaderCell)[]> -- line number -> header/data/footer cells
+---@field nav_linenrs integer[] -- navigable content line numbers, top to bottom
+---@field size? { width: integer, height: integer }
 
 ---@class nui_table_options
 ---@field bufnr integer
 ---@field ns_id integer|string
 ---@field columns NuiTable.ColumnDef[]
 ---@field data table[]
+---@field border? 'none'|table<nui_table_border_char_name, string> border characters, or `'none'` for a borderless table
+---@field buf_options? table<string, any>
 
 ---@class NuiTable
 ---@field private _ nui_table_internal
@@ -169,7 +199,16 @@ function Table:init(options)
 
   self.ns_id = _.normalize_namespace_id(options.ns_id)
 
-  local border = vim.tbl_deep_extend("keep", options.border or {}, default_border)
+  local has_border = options.border ~= "none"
+  local border = has_border and vim.tbl_deep_extend("keep", options.border --[[@as table]] or {}, default_border)
+    -- borderless: columns are separated by a single space and no horizontal
+    -- (border) lines are drawn.
+    or vim.tbl_map(function()
+      return ""
+    end, default_border)
+  if not has_border then
+    border.ver = " "
+  end
 
   self._ = {
     buf_options = vim.tbl_extend("force", {
@@ -182,6 +221,7 @@ function Table:init(options)
       undolevels = 0,
     }, options.buf_options or {}),
     border = border,
+    has_border = has_border,
 
     headers = { depth = 1 },
     columns = {},
@@ -191,7 +231,8 @@ function Table:init(options)
     has_footer = false,
 
     linenr = {},
-    data_linenrs = {},
+    line_cells = {},
+    nav_linenrs = {},
   }
 
   prepare_columns(self._, options.columns or {})
@@ -199,13 +240,18 @@ function Table:init(options)
   _.set_buf_options(self.bufnr, self._.buf_options)
 end
 
----@param current_width integer
----@param min_width? integer
----@param max_width? integer
+---@param column NuiTable.Column|NuiTable.ColumnDef
 ---@param content_width integer
-local function get_col_width(current_width, min_width, max_width, content_width)
-  local min = math.max(content_width, min_width or 0)
-  return math.max(current_width, math.min(max_width or min, min))
+local function fit_col_width(column, content_width)
+  -- fixed-width columns are never resized to fit content.
+  if column._fixed_width then
+    return
+  end
+  local width = math.max(column.width, content_width)
+  if column.max_width then
+    width = math.min(width, column.max_width)
+  end
+  column.width = width
 end
 
 ---@generic C: table
@@ -247,9 +293,11 @@ local function prepare_header_grid(kind, columns, grid, max_depth)
       --[[@cast content -string]]
     end
 
-    column.width = get_col_width(column.width, column.min_width, column.max_width, content:width())
+    --[[@cast column NuiTable.Column]]
+    fit_col_width(column, content:width())
 
     local cell = {
+      type = kind == 1 and "header" or "footer",
       column = column,
       content = content,
       col_span = 1,
@@ -288,6 +336,10 @@ end
 ---@return nui_t_list<NuiTable.Cell[]> data_grid
 ---@return nui_t_list<nui_t_list<table>> header_grid
 function Table:_prepare_grid()
+  -- recompute widths from scratch on every render, so that columns can
+  -- shrink when the data changes (e.g. after :set_data).
+  reset_column_widths(self._.headers)
+
   ---@type nui_t_list<NuiTable.Cell[]>
   local data_grid = {}
 
@@ -320,6 +372,7 @@ function Table:_prepare_grid()
 
       ---@type NuiTable.Cell
       local cell = {
+        type = "data",
         row = row,
         column = column,
         get_value = function()
@@ -329,7 +382,7 @@ function Table:_prepare_grid()
 
       cell.content = prepare_cell_content(cell)
 
-      column.width = get_col_width(column.width, column.min_width, column.max_width, cell.content:width())
+      fit_col_width(column, cell.content:width())
 
       data_grid[row_idx][column_idx] = cell
     end
@@ -383,7 +436,8 @@ end
 ---@param kind _nui_table_header_kind
 ---@param lines nui_t_list<NuiLine>
 ---@param grid nui_t_list<nui_t_list<table>>
-function Table:_prepare_header_lines(kind, lines, grid)
+---@param linenr_start integer buffer line number of lines[1]
+function Table:_prepare_header_lines(kind, lines, grid, linenr_start)
   local line_idx = lines.len
 
   local start_idx, end_idx = 1, grid.len
@@ -406,6 +460,10 @@ function Table:_prepare_header_lines(kind, lines, grid)
     outer_border_line:append(kind == 1 and border.down_right or border.up_right)
 
     data_line:append(border.ver)
+    local char_idx = 1
+
+    ---@type NuiTable.HeaderCell[]
+    local row_cells = {}
 
     local cells_len = #row
     for cell_idx = 1, cells_len do
@@ -450,6 +508,10 @@ function Table:_prepare_header_lines(kind, lines, grid)
       end
       data_line:append(border.ver)
 
+      cell.range = { 0, char_idx, 0, char_idx + column.width }
+      char_idx = cell.range[4] + 1
+      row_cells[#row_cells + 1] = cell
+
       outer_border_line:append(string.rep(border.hor, column.width))
       outer_border_line:append(kind == 1 and border.down_hor or border.up_hor)
     end
@@ -463,21 +525,35 @@ function Table:_prepare_header_lines(kind, lines, grid)
 
     outer_border_line._texts[#outer_border_line._texts]:set(kind == 1 and border.down_left or border.up_left)
 
-    if kind == -1 then
-      line_idx = line_idx + 1
-      lines[line_idx] = inner_border_line
-    elseif row_idx == 1 then
-      line_idx = line_idx + 1
-      lines[line_idx] = outer_border_line
+    if self._.has_border then
+      if kind == -1 then
+        line_idx = line_idx + 1
+        lines[line_idx] = inner_border_line
+      elseif row_idx == 1 then
+        line_idx = line_idx + 1
+        lines[line_idx] = outer_border_line
+      end
     end
     line_idx = line_idx + 1
     lines[line_idx] = data_line
-    if kind == 1 then
-      line_idx = line_idx + 1
-      lines[line_idx] = inner_border_line
-    elseif row_idx == -1 then
-      line_idx = line_idx + 1
-      lines[line_idx] = outer_border_line
+
+    -- record the buffer position of this row's cells for get_cell lookup
+    local linenr = linenr_start + line_idx - 1
+    for _, header_cell in ipairs(row_cells) do
+      header_cell.range[1] = linenr
+      header_cell.range[3] = linenr
+    end
+    self._.line_cells[linenr] = row_cells
+    self._.nav_linenrs[#self._.nav_linenrs + 1] = linenr
+
+    if self._.has_border then
+      if kind == 1 then
+        line_idx = line_idx + 1
+        lines[line_idx] = inner_border_line
+      elseif row_idx == -1 then
+        line_idx = line_idx + 1
+        lines[line_idx] = outer_border_line
+      end
     end
   end
 
@@ -495,20 +571,21 @@ function Table:render(linenr_start)
 
   local data_grid, header_grid = self:_prepare_grid()
 
-  self._.data_grid = data_grid
+  self._.line_cells = {}
+  self._.nav_linenrs = {}
 
   local line_idx = 0
   ---@type nui_t_list<NuiLine>
   local lines = { len = line_idx }
 
-  self:_prepare_header_lines(1, lines, header_grid)
+  self:_prepare_header_lines(1, lines, header_grid, linenr_start)
   line_idx = lines.len
 
   local border = self._.border
 
   local rows_len = data_grid.len
 
-  if line_idx == 0 and rows_len > 0 then
+  if line_idx == 0 and rows_len > 0 and self._.has_border then
     local columns = self._.columns
     local columns_len = #columns
 
@@ -527,8 +604,6 @@ function Table:render(linenr_start)
     line_idx = line_idx + 1
     lines[line_idx] = top_border_line
   end
-
-  local data_linenrs = self._.data_linenrs
 
   for row_idx = 1, rows_len do
     local char_idx = 0
@@ -566,18 +641,23 @@ function Table:render(linenr_start)
     line_idx = line_idx + 1
     lines[line_idx] = data_line
 
-    data_linenrs[row_idx] = data_linenr
+    self._.line_cells[data_linenr] = row
+    self._.nav_linenrs[#self._.nav_linenrs + 1] = data_linenr
 
-    if not is_last_line or not header_grid[-1] then
+    if self._.has_border and (not is_last_line or not header_grid[-1]) then
       line_idx = line_idx + 1
       lines[line_idx] = bottom_border_line
     end
   end
 
   lines.len = line_idx
-  self:_prepare_header_lines(-1, lines, header_grid)
+  self:_prepare_header_lines(-1, lines, header_grid, linenr_start)
   line_idx = lines.len
   lines.len = nil
+
+  -- every rendered line is padded to the full table width, so line 1 is
+  -- representative of the table's width.
+  self._.size = { width = line_idx > 0 and lines[1]:width() or 0, height = line_idx }
 
   _.set_buf_options(self.bufnr, { modifiable = true, readonly = false })
 
@@ -600,37 +680,128 @@ function Table:render(linenr_start)
   self._.linenr[1], self._.linenr[2] = linenr_start, line_idx + linenr_start - 1
 end
 
----@param position? {[1]: integer, [2]: integer}
-function Table:get_cell(position)
-  local pos = vim.fn.getcharpos(".") --[[@as integer[] ]]
-  local line, char = pos[2], pos[3]
+---@param data? table[]
+---@return NuiTable self
+function Table:set_data(data)
+  self._.data = data or {}
+  return self
+end
 
-  local row_idx = 0
-  for idx, linenr in ipairs(self._.data_linenrs) do
-    if linenr == line then
-      row_idx = idx
-      break
-    elseif linenr > line then
+---@return { width: integer, height: integer }|nil size dimensions of the last render
+function Table:get_size()
+  return self._.size
+end
+
+---Finds the cell on `line` whose range contains char column `char`.
+---When `char` falls on a border/gap, biases to the cell on its right.
+---@param cells (NuiTable.Cell|NuiTable.HeaderCell)[]
+---@param char integer
+---@return NuiTable.Cell|NuiTable.HeaderCell|nil
+local function resolve_cell_at(cells, char)
+  for i = 1, #cells do
+    local range = cells[i].range
+    if range[2] < char and char <= range[4] then
+      return cells[i]
+    end
+  end
+  -- on a border/gap: bias right (first cell starting at or after `char`)
+  for i = 1, #cells do
+    if cells[i].range[2] >= char then
+      return cells[i]
+    end
+  end
+end
+
+---Resolves the target cell (and where the cursor should go) for a position
+---relative to `(line, char)`, over the continuous header/data/footer grid.
+---@param line integer
+---@param char integer
+---@param position? {[1]: integer, [2]: integer}
+---@return NuiTable.Cell|NuiTable.HeaderCell|nil cell
+---@return integer? target_line
+---@return integer? target_char
+function Table:_resolve_cell(line, char, position)
+  local row_delta = position and position[1] or 0
+  local col_delta = position and position[2] or 0
+
+  local nav = self._.nav_linenrs
+  local line_index
+  for i = 1, #nav do
+    if nav[i] == line then
+      line_index = i
       break
     end
   end
-  row_idx = row_idx + (position and position[1] or 0)
-
-  local row = self._.data_grid[row_idx]
-  if not row then
+  if not line_index then
     return
   end
 
-  local cell_idx = 0
-  for idx, cell in ipairs(row) do
-    local range = cell.range
-    if range[2] < char and char <= range[4] then
-      cell_idx = idx
+  -- vertical move: step to the adjacent navigable line, keeping the x column
+  local target_line = line
+  if row_delta ~= 0 then
+    target_line = nav[line_index + row_delta]
+    if not target_line then
+      return
     end
   end
-  cell_idx = cell_idx + (position and position[2] or 0)
 
-  return row[cell_idx]
+  local cells = self._.line_cells[target_line]
+  local cell = cells and resolve_cell_at(cells, char)
+  if not cell then
+    return
+  end
+
+  local target_char
+  if col_delta ~= 0 then
+    -- horizontal move: step to the adjacent cell in the (target) line
+    local cell_index
+    for i = 1, #cells do
+      if cells[i] == cell then
+        cell_index = i
+        break
+      end
+    end
+    cell = cells[cell_index + col_delta]
+    if not cell then
+      return
+    end
+    -- range[2] is the border before the cell, so content starts at +1.
+    target_char = cell.range[2] + 1
+  elseif row_delta ~= 0 then
+    target_char = char -- pure vertical move: preserve the x column
+  else
+    target_char = cell.range[2] + 1 -- no move: snap to the current cell
+  end
+
+  return cell, target_line, target_char
+end
+
+---Returns the cell relative to the one under the cursor, over the continuous
+---header/data/footer grid. Vertical moves keep the cursor's column; horizontal
+---moves step cell-by-cell. Returns nil past the grid edges or off any cell.
+---@param position? {[1]: integer, [2]: integer} `(row, col)` tuple relative to cursor
+---@return NuiTable.Cell|NuiTable.HeaderCell|nil
+function Table:get_cell(position)
+  local pos = vim.fn.getcharpos(".") --[[@as integer[] ]]
+  local cell = self:_resolve_cell(pos[2], pos[3], position)
+  return cell
+end
+
+---Moves the cursor to the cell at the given position, relative to the cell
+---under the cursor. Vertical moves keep the column; horizontal moves snap to the
+---target cell's content. No-op (returns nil) if there's no cell there.
+---@param position? {[1]: integer, [2]: integer} `(row, col)` tuple relative to cursor
+---@return NuiTable.Cell|NuiTable.HeaderCell|nil cell the cell the cursor was moved to
+function Table:goto_cell(position)
+  local pos = vim.fn.getcharpos(".") --[[@as integer[] ]]
+  local cell, target_line, target_char = self:_resolve_cell(pos[2], pos[3], position)
+  if not cell then
+    return
+  end
+
+  vim.fn.setcharpos(".", { 0, target_line, target_char, 0 })
+
+  return cell
 end
 
 function Table:refresh_cell(cell)

--- a/tests/nui/table/init_spec.lua
+++ b/tests/nui/table/init_spec.lua
@@ -7,6 +7,109 @@ local h = require("tests.helpers")
 
 local eq = h.eq
 
+local function id_value_columns()
+  return {
+    { accessor_key = "id" },
+    { accessor_key = "value" },
+  }
+end
+
+local function sample_data()
+  return {
+    {
+      firstName = "tanner",
+      lastName = "linsley",
+      age = 24,
+      visits = 100,
+      status = "In Relationship",
+      progress = 50,
+    },
+    {
+      firstName = "tandy",
+      lastName = "miller",
+      age = 40,
+      visits = 40,
+      status = "Single",
+      progress = 80,
+    },
+    {
+      firstName = "joe",
+      lastName = "dirte",
+      age = 45,
+      visits = 20,
+      status = "Complicated",
+      progress = 10,
+    },
+  }
+end
+
+local function grouped_columns_fixture()
+  return {
+    {
+      header = "Name",
+      footer = function(info)
+        return info.column.id
+      end,
+      columns = {
+        {
+          accessor_key = "firstName",
+          footer = "firstName",
+        },
+        {
+          id = "lastName",
+          header = "Last Name",
+          accessor_key = "lastName",
+          footer = function(info)
+            return info.column.id
+          end,
+        },
+      },
+    },
+    {
+      header = "Info",
+      footer = function(info)
+        return info.column.id
+      end,
+      columns = {
+        {
+          header = "Age",
+          accessor_key = "age",
+          footer = "age",
+        },
+        {
+          header = "More Info",
+          footer = function(info)
+            return info.column.id
+          end,
+          columns = {
+            {
+              accessor_key = "visits",
+              header = "Visits",
+              footer = function(info)
+                return info.column.id
+              end,
+            },
+            {
+              accessor_key = "status",
+              header = "Status",
+              footer = function(info)
+                return info.column.id
+              end,
+            },
+          },
+        },
+      },
+    },
+    {
+      header = "Profile Progress",
+      accessor_key = "progress",
+      footer = function(info)
+        return info.column.id
+      end,
+    },
+  }
+end
+
 describe("nui.table", function()
   ---@type number, number
   local winid, bufnr
@@ -171,32 +274,7 @@ describe("nui.table", function()
         },
       }
 
-      data = {
-        {
-          firstName = "tanner",
-          lastName = "linsley",
-          age = 24,
-          visits = 100,
-          status = "In Relationship",
-          progress = 50,
-        },
-        {
-          firstName = "tandy",
-          lastName = "miller",
-          age = 40,
-          visits = 40,
-          status = "Single",
-          progress = 80,
-        },
-        {
-          firstName = "joe",
-          lastName = "dirte",
-          age = 45,
-          visits = 20,
-          status = "Complicated",
-          progress = 10,
-        },
-      }
+      data = sample_data()
     end)
 
     it("can handle empty columns", function()
@@ -386,79 +464,11 @@ describe("nui.table", function()
     end)
 
     describe("grouped columns", function()
-      local grouped_columns
-      before_each(function()
-        grouped_columns = {
-          {
-            header = "Name",
-            footer = function(info)
-              return info.column.id
-            end,
-            columns = {
-              {
-                accessor_key = "firstName",
-                footer = "firstName",
-              },
-              {
-                id = "lastName",
-                header = "Last Name",
-                accessor_key = "lastName",
-                footer = function(info)
-                  return info.column.id
-                end,
-              },
-            },
-          },
-          {
-            header = "Info",
-            footer = function(info)
-              return info.column.id
-            end,
-            columns = {
-              {
-                header = "Age",
-                accessor_key = "age",
-                footer = "age",
-              },
-              {
-                header = "More Info",
-                footer = function(info)
-                  return info.column.id
-                end,
-                columns = {
-                  {
-                    accessor_key = "visits",
-                    header = "Visits",
-                    footer = function(info)
-                      return info.column.id
-                    end,
-                  },
-                  {
-                    accessor_key = "status",
-                    header = "Status",
-                    footer = function(info)
-                      return info.column.id
-                    end,
-                  },
-                },
-              },
-            },
-          },
-          {
-            header = "Profile Progress",
-            accessor_key = "progress",
-            footer = function(info)
-              return info.column.id
-            end,
-          },
-        }
-      end)
-
       it("is drawn correctly", function()
         local table = Table({
           bufnr = bufnr,
-          columns = grouped_columns,
-          data = data,
+          columns = grouped_columns_fixture(),
+          data = sample_data(),
         })
 
         table:render()
@@ -486,6 +496,95 @@ describe("nui.table", function()
         })
       end)
     end)
+
+    describe("borderless (border = 'none')", function()
+      it("draws no border lines, separating columns with a space", function()
+        local table = Table({
+          bufnr = bufnr,
+          border = "none",
+          columns = id_value_columns(),
+          data = {
+            { id = 1, value = "One" },
+            { id = 2, value = "Two" },
+          },
+        })
+
+        table:render()
+
+        h.assert_buf_lines(table.bufnr, {
+          " 1 One ",
+          " 2 Two ",
+        })
+      end)
+
+      it("works w/ header w/ footer", function()
+        local table = Table({
+          bufnr = bufnr,
+          border = "none",
+          columns = { { accessor_key = "value", header = "Val", footer = "Val" } },
+          data = { { value = "one" } },
+        })
+
+        table:render()
+
+        h.assert_buf_lines(table.bufnr, {
+          " Val ",
+          " one ",
+          " Val ",
+        })
+      end)
+
+      it("maps consecutive rows onto consecutive lines", function()
+        local table = Table({
+          bufnr = bufnr,
+          border = "none",
+          columns = id_value_columns(),
+          data = {
+            { id = 1, value = "One" },
+            { id = 2, value = "Two" },
+            { id = 3, value = "Three" },
+          },
+        })
+
+        table:render()
+
+        -- rows sit on consecutive lines, no separator line in between
+        h.assert_buf_lines(table.bufnr, {
+          " 1 One   ",
+          " 2 Two   ",
+          " 3 Three ",
+        })
+      end)
+
+      it("renders grouped columns", function()
+        local table = Table({
+          bufnr = bufnr,
+          border = "none",
+          columns = {
+            {
+              header = "Name",
+              columns = {
+                { accessor_key = "first", header = "First" },
+                { accessor_key = "last", header = "Last" },
+              },
+            },
+            { accessor_key = "age", header = "Age" },
+          },
+          data = { { first = "a", last = "bb", age = 1 } },
+        })
+
+        table:render()
+
+        -- no border chars, no horizontal rules; the group header spans its
+        -- leaf columns and every line is padded to the full table width.
+        h.assert_buf_lines(table.bufnr, {
+          " Name           ",
+          " First Last Age ",
+          " a     bb   1   ",
+        })
+        eq(table:get_size(), { width = 16, height = 3 })
+      end)
+    end)
   end)
 
   describe("method :get_cell", function()
@@ -503,6 +602,26 @@ describe("nui.table", function()
       local cell = table:get_cell()
 
       eq(cell, nil)
+    end)
+
+    it("biases right when the cursor is on an internal vertical border", function()
+      local table = Table({
+        bufnr = bufnr,
+        columns = id_value_columns(),
+        data = { { id = 1, value = "One" } },
+      })
+
+      table:render()
+
+      -- ┌─┬───┐
+      -- │1│One│   <- line 2; the internal `│` between the cells is at byte col 4
+      -- └─┴───┘
+      vim.api.nvim_win_set_cursor(winid, { 2, 4 })
+
+      -- the cursor isn't on any cell content, so get_cell biases to the right
+      local cell = table:get_cell()
+      eq(cell.column.id, "value")
+      eq(cell.get_value(), "One")
     end)
 
     it("works after shifting", function()
@@ -536,10 +655,7 @@ describe("nui.table", function()
     it("can take position", function()
       local table = Table({
         bufnr = bufnr,
-        columns = {
-          { accessor_key = "id" },
-          { accessor_key = "value" },
-        },
+        columns = id_value_columns(),
         data = {
           { id = 1, value = "One" },
           { id = 2, value = "Two" },
@@ -556,6 +672,338 @@ describe("nui.table", function()
 
       cell = table:get_cell({ 1, 1 })
       eq(cell.get_value(), "Two")
+    end)
+
+    describe("grouped columns", function()
+      it("resolves header and footer cells", function()
+        local table = Table({
+          bufnr = bufnr,
+          columns = grouped_columns_fixture(),
+          data = sample_data(),
+        })
+
+        table:render()
+
+        local function at(line, col)
+          vim.api.nvim_win_set_cursor(winid, { line, col })
+          return table:get_cell()
+        end
+
+        -- header group row (line 2): top-level groups
+        local cell = at(2, 3) -- "Name" group
+        eq(cell.type, "header")
+        eq(cell.column.id, "Name")
+
+        cell = at(2, 25) -- "Info" group
+        eq(cell.type, "header")
+        eq(cell.column.id, "Info")
+
+        -- a spanned-empty group area still resolves to its group cell:
+        -- on line 2, the rightmost region belongs to "Profile Progress"
+        cell = at(2, 55)
+        eq(cell.type, "header")
+        eq(cell.column.id, "progress")
+
+        -- leaf header row (line 6)
+        cell = at(6, 3) -- firstName
+        eq(cell.type, "header")
+        eq(cell.column.id, "firstName")
+
+        cell = at(6, 27) -- Age
+        eq(cell.type, "header")
+        eq(cell.column.id, "age")
+
+        -- footer leaf row (line 14)
+        cell = at(14, 3)
+        eq(cell.type, "footer")
+        eq(cell.column.id, "firstName")
+
+        -- footer group row (line 18)
+        cell = at(18, 3)
+        eq(cell.type, "footer")
+        eq(cell.column.id, "Name")
+
+        -- data cells still resolve as type "data" (line 8)
+        cell = at(8, 3)
+        eq(cell.type, "data")
+        eq(cell.get_value(), "tanner")
+
+        -- a border line resolves to nothing
+        eq(at(1, 4), nil)
+      end)
+    end)
+
+    describe("borderless (border = 'none')", function()
+      it("maps each consecutive line to the correct row", function()
+        local table = Table({
+          bufnr = bufnr,
+          border = "none",
+          columns = id_value_columns(),
+          data = {
+            { id = 1, value = "One" },
+            { id = 2, value = "Two" },
+            { id = 3, value = "Three" },
+          },
+        })
+
+        table:render()
+
+        -- consecutive rows share no separator line, so each buffer line maps
+        -- directly to the row at the same index
+        vim.api.nvim_win_set_cursor(winid, { 1, 1 })
+        eq(table:get_cell().get_value(), 1)
+        vim.api.nvim_win_set_cursor(winid, { 2, 1 })
+        eq(table:get_cell().get_value(), 2)
+        vim.api.nvim_win_set_cursor(winid, { 3, 1 })
+        eq(table:get_cell().get_value(), 3)
+      end)
+    end)
+  end)
+
+  describe("method :goto_cell", function()
+    describe("flat columns", function()
+      local table
+
+      before_each(function()
+        table = Table({
+          bufnr = bufnr,
+          columns = id_value_columns(),
+          data = {
+            { id = 1, value = "One" },
+            { id = 2, value = "Two" },
+          },
+        })
+
+        table:render()
+
+        -- ┌─┬───┐   line 1
+        -- │1│One│   line 2
+        -- ├─┼───┤   line 3
+        -- │2│Two│   line 4
+        -- └─┴───┘   line 5
+        --
+        -- `│` is 3 bytes wide, so (0-indexed) byte cols are:
+        --   id cell content    -> col 3
+        --   value cell content -> col 7
+
+        -- start on row 1, id cell
+        vim.api.nvim_win_set_cursor(winid, { 2, 3 })
+      end)
+
+      it("moves over borders to the next/prev column and row", function()
+        local cell
+
+        cell = table:goto_cell({ 0, 1 }) -- right -> row 1, value
+        eq(cell.get_value(), "One")
+        eq(vim.api.nvim_win_get_cursor(winid), { 2, 7 })
+
+        cell = table:goto_cell({ 1, 0 }) -- down -> row 2, value
+        eq(cell.get_value(), "Two")
+        eq(vim.api.nvim_win_get_cursor(winid), { 4, 7 })
+
+        cell = table:goto_cell({ 0, -1 }) -- left -> row 2, id
+        eq(cell.get_value(), 2)
+        eq(vim.api.nvim_win_get_cursor(winid), { 4, 3 })
+
+        cell = table:goto_cell({ -1, 0 }) -- up -> row 1, id
+        eq(cell.get_value(), 1)
+        eq(vim.api.nvim_win_get_cursor(winid), { 2, 3 })
+      end)
+
+      it("is a no-op at the table edges", function()
+        -- at row 1, id cell: no cell above or to the left
+        eq(table:goto_cell({ -1, 0 }), nil)
+        eq(vim.api.nvim_win_get_cursor(winid), { 2, 3 })
+
+        eq(table:goto_cell({ 0, -1 }), nil)
+        eq(vim.api.nvim_win_get_cursor(winid), { 2, 3 })
+      end)
+
+      it("snaps to the current cell content when given no position", function()
+        -- cursor sits on the id cell content already; snapping keeps it there
+        vim.api.nvim_win_set_cursor(winid, { 4, 7 })
+
+        local cell = table:goto_cell()
+        eq(cell.get_value(), "Two")
+        eq(vim.api.nvim_win_get_cursor(winid), { 4, 7 })
+      end)
+    end)
+
+    describe("grouped columns", function()
+      it("navigates the leaf columns", function()
+        local table = Table({
+          bufnr = bufnr,
+          columns = grouped_columns_fixture(),
+          data = sample_data(),
+        })
+
+        table:render()
+
+        -- per the layout above, row 1 (tanner) content is on line 8,
+        -- with "tanner" starting at byte col 3 (after the 3-byte `│`).
+        vim.api.nvim_win_set_cursor(winid, { 8, 3 })
+
+        local function at(cell, row_index, column_id, value)
+          eq(cell.row.index, row_index)
+          eq(cell.column.id, column_id)
+          eq(cell.get_value(), value)
+          -- cursor actually landed on this cell: re-resolving finds the same one
+          eq(table:get_cell().column.id, column_id)
+          eq(table:get_cell().row.index, row_index)
+        end
+
+        at(table:get_cell(), 1, "firstName", "tanner")
+
+        -- walk right across every leaf column, skipping the grouping borders
+        at(table:goto_cell({ 0, 1 }), 1, "lastName", "linsley")
+        at(table:goto_cell({ 0, 1 }), 1, "age", 24)
+        at(table:goto_cell({ 0, 1 }), 1, "visits", 100)
+        at(table:goto_cell({ 0, 1 }), 1, "status", "In Relationship")
+        at(table:goto_cell({ 0, 1 }), 1, "progress", 50)
+
+        -- right of the last leaf column is a no-op
+        eq(table:goto_cell({ 0, 1 }), nil)
+
+        -- vertical + horizontal moves resolve to the right leaf cells
+        at(table:goto_cell({ 1, 0 }), 2, "progress", 80)
+        at(table:goto_cell({ 0, -1 }), 2, "status", "Single")
+        at(table:goto_cell({ -1, 0 }), 1, "status", "In Relationship")
+      end)
+
+      it("navigates continuously across header, data, and footer", function()
+        local table = Table({
+          bufnr = bufnr,
+          columns = grouped_columns_fixture(),
+          data = sample_data(),
+        })
+
+        table:render()
+
+        -- start on the Status data cell of row 1 (line 8); byte 42 is the "I"
+        -- of "In Relationship" (the Status column's content).
+        vim.api.nvim_win_set_cursor(winid, { 8, 42 })
+        local cell = table:get_cell()
+        eq(cell.type, "data")
+        eq(cell.column.id, "status")
+        eq(cell.get_value(), "In Relationship")
+
+        -- up from data into the header stack, following the Status column
+        eq(table:goto_cell({ -1, 0 }).column.id, "status") -- leaf header
+        eq(table:goto_cell({ -1, 0 }).column.id, "More Info") -- group
+        cell = table:goto_cell({ -1, 0 })
+        eq(cell.type, "header")
+        eq(cell.column.id, "Info") -- top-level group
+
+        -- top edge is a no-op
+        eq(table:goto_cell({ -1, 0 }), nil)
+
+        -- coming back down returns to the SAME leaf column (cursor-x carries it)
+        eq(table:goto_cell({ 1, 0 }).column.id, "More Info")
+        eq(table:goto_cell({ 1, 0 }).column.id, "status")
+        cell = table:goto_cell({ 1, 0 })
+        eq(cell.type, "data")
+        eq(cell.column.id, "status")
+        eq(cell.get_value(), "In Relationship")
+
+        -- continue down through the data rows into the footer
+        eq(table:goto_cell({ 1, 0 }).get_value(), "Single") -- row 2
+        eq(table:goto_cell({ 1, 0 }).get_value(), "Complicated") -- row 3
+        cell = table:goto_cell({ 1, 0 }) -- into the footer
+        eq(cell.type, "footer")
+        eq(cell.column.id, "status")
+
+        -- horizontal stepping within a header (group) row
+        vim.api.nvim_win_set_cursor(winid, { 2, 3 }) -- "Name" group
+        eq(table:get_cell().column.id, "Name")
+        eq(table:goto_cell({ 0, 1 }).column.id, "Info")
+        eq(table:goto_cell({ 0, 1 }).column.id, "progress") -- Profile Progress
+        eq(table:goto_cell({ 0, 1 }), nil) -- right edge is a no-op
+      end)
+
+      it("biases right when a vertical move lands on a border", function()
+        local table = Table({
+          bufnr = bufnr,
+          columns = grouped_columns_fixture(),
+          data = sample_data(),
+        })
+
+        table:render()
+
+        -- line 4 is the "More Info" header row; byte 39 is char col 32, which
+        -- sits inside More Info's content but lines up exactly with the
+        -- Visits│Status border on the leaf header row (line 6).
+        vim.api.nvim_win_set_cursor(winid, { 4, 39 })
+        eq(table:get_cell().column.id, "More Info")
+
+        -- moving down keeps that x; on line 6 it's a border, so it biases right
+        -- to Status (it would be Visits if it biased left)
+        local cell = table:goto_cell({ 1, 0 })
+        eq(cell.type, "header")
+        eq(cell.column.id, "status")
+      end)
+    end)
+
+    describe("borderless (border = 'none')", function()
+      it("navigates row and column moves", function()
+        local table = Table({
+          bufnr = bufnr,
+          border = "none",
+          columns = id_value_columns(),
+          data = {
+            { id = 1, value = "One" },
+            { id = 2, value = "Two" },
+          },
+        })
+
+        table:render()
+
+        vim.api.nvim_win_set_cursor(winid, { 1, 1 }) -- on "1"
+        eq(table:get_cell().get_value(), 1)
+
+        local cell = table:goto_cell({ 0, 1 }) -- right -> value
+        eq(cell.get_value(), "One")
+        eq(vim.api.nvim_win_get_cursor(winid), { 1, 3 })
+
+        cell = table:goto_cell({ 1, 0 }) -- down -> row 2 value
+        eq(cell.get_value(), "Two")
+        eq(vim.api.nvim_win_get_cursor(winid), { 2, 3 })
+      end)
+
+      it("navigates grouped columns", function()
+        local table = Table({
+          bufnr = bufnr,
+          border = "none",
+          columns = {
+            {
+              header = "Name",
+              columns = {
+                { accessor_key = "first", header = "First" },
+                { accessor_key = "last", header = "Last" },
+              },
+            },
+            { accessor_key = "age", header = "Age" },
+          },
+          data = { { first = "a", last = "bb", age = 1 } },
+        })
+
+        table:render()
+
+        -- data cell resolves, then walks up into the leaf and group headers,
+        -- proving the recomputed group widths line up across the grid.
+        vim.api.nvim_win_set_cursor(winid, { 3, 1 }) -- on "a"
+        eq(table:get_cell().column.id, "first")
+
+        local cell = table:goto_cell({ -1, 0 }) -- up -> leaf header
+        eq(cell.type, "header")
+        eq(cell.column.id, "first")
+
+        cell = table:goto_cell({ -1, 0 }) -- up -> group header
+        eq(cell.type, "header")
+        eq(cell.column.id, "Name")
+
+        -- horizontal step within the group-header row reaches the Age group
+        eq(table:goto_cell({ 0, 1 }).column.id, "age")
+      end)
     end)
   end)
 
@@ -627,6 +1075,254 @@ describe("nui.table", function()
         "│100 years o…│",
         "└────────────┘",
       })
+    end)
+
+    describe("borderless (border = 'none')", function()
+      it("refreshes the correct row when rows share no separator", function()
+        local table = Table({
+          bufnr = bufnr,
+          border = "none",
+          columns = id_value_columns(),
+          data = {
+            { id = 1, value = "One" },
+            { id = 2, value = "Two" },
+            { id = 3, value = "Three" },
+          },
+        })
+
+        table:render()
+
+        -- refreshing a non-first row edits only that line, even though the
+        -- borderless rows sit on consecutive lines with no separator
+        vim.api.nvim_win_set_cursor(winid, { 3, 4 })
+        local cell = table:get_cell()
+        eq(cell.get_value(), "Three")
+
+        cell.row.original.value = "XXX"
+        table:refresh_cell(cell)
+
+        h.assert_buf_lines(table.bufnr, {
+          " 1 One   ",
+          " 2 Two   ",
+          " 3 XXX   ",
+        })
+      end)
+    end)
+  end)
+
+  describe("method :set_data", function()
+    it("replaces data on next render", function()
+      local table = Table({
+        bufnr = bufnr,
+        columns = { { accessor_key = "value" } },
+        data = { { value = "one" } },
+      })
+
+      table:render()
+
+      h.assert_buf_lines(table.bufnr, {
+        "┌───┐",
+        "│one│",
+        "└───┘",
+      })
+
+      table:set_data({ { value = "two" }, { value = "three" } })
+      table:render()
+
+      h.assert_buf_lines(table.bufnr, {
+        "┌─────┐",
+        "│two  │",
+        "├─────┤",
+        "│three│",
+        "└─────┘",
+      })
+    end)
+
+    it("returns self for chaining", function()
+      local table = Table({
+        bufnr = bufnr,
+        columns = { { accessor_key = "value" } },
+        data = {},
+      })
+
+      eq(table:set_data({ { value = "x" } }), table)
+    end)
+
+    it("shrinks column width when new data is narrower", function()
+      local table = Table({
+        bufnr = bufnr,
+        columns = { { accessor_key = "value" } },
+        data = { { value = "loooooong" } },
+      })
+
+      table:render()
+
+      h.assert_buf_lines(table.bufnr, {
+        "┌─────────┐",
+        "│loooooong│",
+        "└─────────┘",
+      })
+
+      table:set_data({ { value = "hi" } })
+      table:render()
+
+      h.assert_buf_lines(table.bufnr, {
+        "┌──┐",
+        "│hi│",
+        "└──┘",
+      })
+    end)
+
+    it("keeps a configured width fixed, truncating wider content", function()
+      local table = Table({
+        bufnr = bufnr,
+        columns = { { accessor_key = "value", width = 6 } },
+        data = { { value = "abcdefgh" } },
+      })
+
+      table:render()
+
+      h.assert_buf_lines(table.bufnr, {
+        "┌──────┐",
+        "│abcde…│",
+        "└──────┘",
+      })
+
+      table:set_data({ { value = "hi" } })
+      table:render()
+
+      h.assert_buf_lines(table.bufnr, {
+        "┌──────┐",
+        "│hi    │",
+        "└──────┘",
+      })
+    end)
+
+    describe("borderless (border = 'none')", function()
+      it("recomputes width on set_data", function()
+        local table = Table({
+          bufnr = bufnr,
+          border = "none",
+          columns = { { accessor_key = "value" } },
+          data = { { value = "one" } },
+        })
+
+        table:render()
+        h.assert_buf_lines(table.bufnr, { " one " })
+
+        table:set_data({ { value = "loooong" } })
+        table:render()
+        h.assert_buf_lines(table.bufnr, { " loooong " })
+      end)
+    end)
+  end)
+
+  describe("column width", function()
+    it("flexes to content when no width is configured", function()
+      local table = Table({
+        bufnr = bufnr,
+        columns = { { accessor_key = "value" } },
+        data = { { value = "hi" }, { value = "loooooong" } },
+      })
+
+      table:render()
+
+      h.assert_buf_lines(table.bufnr, {
+        "┌─────────┐",
+        "│hi       │",
+        "├─────────┤",
+        "│loooooong│",
+        "└─────────┘",
+      })
+    end)
+
+    it("respects min_width when flexing", function()
+      local table = Table({
+        bufnr = bufnr,
+        columns = { { accessor_key = "value", min_width = 6 } },
+        data = { { value = "hi" } },
+      })
+
+      table:render()
+
+      h.assert_buf_lines(table.bufnr, {
+        "┌──────┐",
+        "│hi    │",
+        "└──────┘",
+      })
+    end)
+
+    it("respects max_width when flexing, truncating wider content", function()
+      local table = Table({
+        bufnr = bufnr,
+        columns = { { accessor_key = "value", max_width = 6 } },
+        data = { { value = "abcdefgh" } },
+      })
+
+      table:render()
+
+      h.assert_buf_lines(table.bufnr, {
+        "┌──────┐",
+        "│abcde…│",
+        "└──────┘",
+      })
+    end)
+  end)
+
+  describe("method :get_size", function()
+    it("returns nil before first render", function()
+      local table = Table({
+        bufnr = bufnr,
+        columns = { { accessor_key = "value" } },
+        data = { { value = "one" } },
+      })
+
+      eq(table:get_size(), nil)
+    end)
+
+    it("returns dimensions of the last render", function()
+      local table = Table({
+        bufnr = bufnr,
+        columns = { { accessor_key = "value" } },
+        data = { { value = "one" }, { value = "two" } },
+      })
+
+      table:render()
+
+      eq(table:get_size(), { width = 5, height = 5 })
+    end)
+
+    it("updates after :set_data + :render", function()
+      local table = Table({
+        bufnr = bufnr,
+        columns = { { accessor_key = "value" } },
+        data = { { value = "one" } },
+      })
+
+      table:render()
+      eq(table:get_size(), { width = 5, height = 3 })
+
+      table:set_data({ { value = "loooooong" } })
+      table:render()
+      eq(table:get_size(), { width = 11, height = 3 })
+    end)
+
+    describe("borderless (border = 'none')", function()
+      it("reports size of the borderless layout", function()
+        local table = Table({
+          bufnr = bufnr,
+          border = "none",
+          columns = id_value_columns(),
+          data = {
+            { id = 1, value = "One" },
+            { id = 2, value = "Two" },
+          },
+        })
+
+        table:render()
+
+        eq(table:get_size(), { width = 7, height = 2 })
+      end)
     end)
   end)
 end)


### PR DESCRIPTION
## Summary

Adds three related `NuiTable` capabilities (roadmap items). The changes are interwoven in `lua/nui/table/init.lua`, so they land as one commit.

### 1. Dynamic data + flexible column widths
- New `tbl:set_data(data)` replaces rows between renders (chainable; call `:render()` after).
- Column widths reflow on every render — they now **shrink** as well as grow to fit content, respecting `min_width`/`max_width`. An explicit `width` keeps the column **fixed** (content is truncated).

### 2. Borderless tables
- New `border = 'none'` option: no horizontal rules, columns separated by a single space.
- Documented the existing `buf_options` option.

### 3. Continuous-grid cell navigation
- `tbl:get_cell()` now navigates a continuous **header + data + footer** grid (previously data-only).
- New `tbl:goto_cell(position)` moves the cursor to the resolved cell.
- New `tbl:get_size()` returns `{ width, height }` of the last render.
- Header/footer cells now carry a `type` (`"header"`/`"footer"`; data cells are `"data"`) and a computed `range`.

## Behavior change
`get_cell({±1, 0})` from the first/last data row now crosses into the header/footer instead of returning `nil`. This is intentional (the continuous-grid feature) but is a semantics change for existing callers.

## Testing
- `bash scripts/test.sh nui/table` → **52 passed, 0 failed**.
- `stylua --check` clean.
- New coverage: borderless (flat + grouped) render/nav/size/set_data, width flex/min/max/fixed, `set_data` reflow (grow + shrink), header/footer navigation, grid-edge no-ops, and border bias-right (including a no-move `get_cell()` on an internal vertical border).